### PR TITLE
Puddletag for Homebrew

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,15 @@ Installing from the Debian package.
 - Install dependencies using your favourite tool.
 - puddletag will appear under your Multimedia menu
 
+
+Installing from Homebrew on Mac OS X.
+-------------------------------------
+
+- This package can be installed on MacOS X via the Homebrew package manager.
+- Install the package manager from http://brew.sh
+- Download and install puddletag by typing "brew install puddletag" in your console
+
+
 License
 =======
 puddletag licensed under the GPLv3, which you can find in its entirety at http://www.gnu.org/licenses/gpl-3.0.html

--- a/source/create_macos_app_bundle.sh
+++ b/source/create_macos_app_bundle.sh
@@ -1,0 +1,94 @@
+#! /bin/bash
+
+function create_bundle_structure () {
+      mkdir -p ${bundleMacOSFolder}
+      mkdir -p ${bundleResourcesFolder}
+}
+
+function provide_app_startup_script () {
+      cp ${appStartupScript} ${bundleMacOSFolder}/${1}
+}
+
+function provide_app_icon () {
+      $(which sips) -s format icns ${2} --out ${bundleResourcesFolder}/${1}.icns > /dev/null
+}
+
+function create_Info.plist () {
+echo -e "<?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>English</string>
+        <key>CFBundleExecutable</key>
+        <string>${2}</string>" > ${1}.app/Contents/Info.plist
+
+if [[ ${3} != "empty" ]]; then
+echo -e "        <key>CFBundleIconFile</key>
+        <string>${3}</string>" >> ${1}.app/Contents/Info.plist
+fi
+
+echo -e "        <key>CFBundleIdentifier</key>
+        <string>com.github.keithgg.puddletag</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleVersion</key>
+        <string>1.0</string>
+        <key>CFBundleSignature</key>
+        <string>PUDDLE</string>
+      </dict>
+      </plist>" >> ${1}.app/Contents/Info.plist
+}
+
+###################################
+# Main routine
+###################################
+appIcon="empty"
+
+while [[ $# > 1 ]]; do
+      key="${1}"
+
+      case $key in
+         -n|--name)
+           appName="${2}"
+           shift # past argument
+           ;;
+
+         -i|--icon)
+           appIcon="${2}"
+           shift # past argument
+           ;;
+
+         -s|--script)
+           appStartupScript="${2}"
+           shift # past argument
+           ;;
+
+         *)
+           echo "Unknown argument \"${key}\"."
+           show_help_message
+           shift # past argument
+           ;;
+      esac
+      shift # past argument or value
+done
+
+if [[ ! $(which sip) ]]; then
+      appIcon="empty"
+fi
+
+# internal vars
+bundleMacOSFolder=${appName}.app/Contents/MacOS
+bundleResourcesFolder=${appName}.app/Contents/Resources
+
+# create the bundle
+create_bundle_structure 
+provide_app_startup_script ${appStartupScript}
+if [[ ${appIcon} != "empty" ]]; then
+       provide_app_icon ${appName} ${appIcon}
+fi
+create_Info.plist ${appName} ${appStartupScript} ${appIcon}
+
+# EoF


### PR DESCRIPTION
Recently I wrote a homebrew formula for puddletag. This was accepted and now puddletag can be install via "brew install puddletag".
I added the comments in the readme.

For a better user experience I also added a script for creating a MacOS Bundle under OS X. This allows for using puddletag on MacOS as a click and run app. A MacOS Bundle is similar to the puddletag.desktop file. The file will be run by the formula on homebrew to create the app bundle. The homebrew maintainers those routine have to be included in upstream products, like puddletag,

I will really appreciate it a lot, if you add these changes into your repo. Puddletag is really a great tool replacing mp3tag on non Windows systems. It is even better than iTunes. That's why the Mac World should be able to use it!

For any changes I surely will send you updates on the respective files!

Hoping you will add my changes.