### PR TITLE
Fix for BitPaddedInt import error

### DIFF
--- a/source/puddlestuff/audioinfo/_compatid3.py
+++ b/source/puddlestuff/audioinfo/_compatid3.py
@@ -23,7 +23,8 @@ from struct import pack, unpack
 import mutagen
 from mutagen._util import insert_bytes
 from mutagen.id3 import ID3, Frame, Frames, Frames_2_2, TextFrame, TORY, \
-    TYER, TIME, APIC, IPLS, TDAT, BitPaddedInt, MakeID3v1
+    TYER, TIME, APIC, IPLS, TDAT, MakeID3v1
+from mutagen.id3._util import BitPaddedInt
 
 SEPARATOR = ' / '
 


### PR DESCRIPTION
This one fix an import error i get with latest python-mutagen 1.34.999+1301~0c8997f-0~ppa0~trusty from https://launchpad.net/~lazka/+archive/ubuntu/dumpingplace