### PR TITLE
Random track numbering in Autonumbering Wizard

### DIFF
--- a/source/puddlestuff/helperwin.py
+++ b/source/puddlestuff/helperwin.py
@@ -112,6 +112,9 @@ class AutonumberDialog(QDialog):
         vbox.addWidget(self.count_by_group)
         self.custom_numbering_widgets.append(self.count_by_group)
 
+        self._shuffle = QCheckBox("Assign numbers in random order")
+        vbox.addLayout(hbox(self._shuffle))
+
         okcancel = OKCancel()
         vbox.addLayout(okcancel)
         self.setLayout(vbox)
@@ -163,7 +166,8 @@ class AutonumberDialog(QDialog):
                   self._padlength.value(),
                   unicode(self.grouping.text()),
                   unicode(self.output_field.currentText()),
-                  self.count_by_group.checkState()
+                  self.count_by_group.checkState(),
+                  self._shuffle.checkState()
         )
         
         self._saveSettings()
@@ -185,6 +189,9 @@ class AutonumberDialog(QDialog):
         self.showDirectorySplittingOptions(self._restart_numbering.checkState())
         
         self.grouping.setText(cparser.get(section, 'grouping', '%__dirpath%'))
+
+        self._shuffle.setCheckState(
+            cparser.get(section, 'shuffle', Qt.Unchecked))
         
         output_field_text = cparser.get(section, 'output_field', 'track')
         if not output_field_text:
@@ -205,6 +212,7 @@ class AutonumberDialog(QDialog):
         cparser.set(section, 'padlength', self._padlength.value())
         cparser.set(section, 'grouping', self.grouping.text())
         cparser.set(section, 'output_field', self.output_field.currentText())
+        cparser.set(section, 'shuffle', self._shuffle.checkState())
 
 class ImportTextFile(QDialog):
     """Dialog that importing a text file to retrieve tags from."""

--- a/source/puddlestuff/mainwin/funcs.py
+++ b/source/puddlestuff/mainwin/funcs.py
@@ -15,6 +15,7 @@ from itertools import izip
 from puddlestuff.audioinfo import stringtags, PATH, DIRPATH, EXTENSION, FILETAGS, tag_to_json
 from operator import itemgetter
 import puddlestuff.musiclib, puddlestuff.about as about
+import random
 import traceback
 from puddlestuff.util import split_by_tag, translate, to_string
 import puddlestuff.functions as functions
@@ -246,7 +247,7 @@ def _pad(trknum, total, padlen):
         text = unicode(trknum).zfill(padlen)
     return text
 
-def number_tracks(tags, offset, numtracks, restartdirs, padlength, split_field='__dirpath', output_field='track', by_group=False):
+def number_tracks(tags, offset, numtracks, restartdirs, padlength, split_field='__dirpath', output_field='track', by_group=False, shuffle_tracks=False):
     """Numbers the selected tracks sequentially in the range
     between the indexes.
     The first item of indices is the starting track.
@@ -280,6 +281,9 @@ def number_tracks(tags, offset, numtracks, restartdirs, padlength, split_field='
     else:
         folders = {'fol': [i for i, t in enumerate(tags)]}
 
+    if(shuffle_tracks):
+        for key in folders:
+            random.shuffle(folders[key])
 
     taglist = {}
     for group_num, tags in enumerate(folders.itervalues()):


### PR DESCRIPTION
I tried to implement the feature of assigning track numbers to a certain set of tracks without a deterministic ordering criterion.

Given that no random sorting of the tracks is available, I thought I could try modifying directly the Autonumbering Wizard code.
