### PR TITLE
Create puddletag_sv.ts

### DIFF
--- a/source/translations/puddletag_sv.ts
+++ b/source/translations/puddletag_sv.ts
@@ -1341,7 +1341,7 @@ Till skaparna av de bibliotek puddletag är beroende av (utan vilka jag troligen
     <message>
         <location filename="puddlestuff/translations.py" line="155"/>
         <source>only as &amp;whole word</source>
-        <translation>endast som &amp;hela ord</translation>
+        <translation>Endast &amp;hela ord</translation>
     </message>
     <message>
         <location filename="puddlestuff/translations.py" line="156"/>
@@ -1860,7 +1860,7 @@ Till skaparna av de bibliotek puddletag är beroende av (utan vilka jag troligen
     <message>
         <location filename="puddlestuff/translations.py" line="60"/>
         <source>&amp;Preserve file modification times</source>
-        <translation>&amp;Bevara filers tidsstämpel</translation>
+        <translation>&amp;Bevara tidsstämpeln &apos;Senast ändrad&apos;</translation>
     </message>
     <message>
         <location filename="puddlestuff/translations.py" line="61"/>
@@ -3020,7 +3020,7 @@ Vill du fortsätta?</translation>
     <message>
         <location filename="puddlestuff/masstag/dialogs.py" line="262"/>
         <source>Minimum percentage required for album matches.</source>
-        <translation>Minimum procentvärde för albummatchning.</translation>
+        <translation>Minimivärde i procent, för albummatchning.</translation>
     </message>
     <message>
         <location filename="puddlestuff/masstag/dialogs.py" line="265"/>

--- a/source/translations/puddletag_sv.ts
+++ b/source/translations/puddletag_sv.ts
@@ -1,0 +1,3657 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+<context>
+    <name>About</name>
+    <message>
+        <location filename="../puddlestuff/about.py" line="61"/>
+        <source>About puddletag</source>
+        <translation>Om puddletag</translation>
+    </message>
+    <message>
+        <location filename="../puddlestuff/about.py" line="73"/>
+        <source>&lt;h2&gt;puddletag %1&lt;/h2&gt; %2</source>
+        <translation>&lt;h2&gt;puddletag %1&lt;/h2&gt; %2</translation>
+    </message>
+    <message>
+        <location filename="../puddlestuff/about.py" line="80"/>
+        <source>&amp;About</source>
+        <translation>&amp;Om</translation>
+    </message>
+    <message>
+        <location filename="../puddlestuff/about.py" line="81"/>
+        <source>&amp;Thanks</source>
+        <translation>&amp;Tack</translation>
+    </message>
+    <message>
+        <location filename="../puddlestuff/about.py" line="68"/>
+        <source>&lt;h2&gt;puddletag %1 (Changeset %2)&lt;/h2&gt; %3</source>
+        <translation>&lt;h2&gt;puddletag %1 (Revision %2)&lt;/h2&gt; %3</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/about.py" line="12"/>
+        <source>puddletag is an audio tag editor for GNU/Linux similar to the Windows program Mp3tag.
+
+&lt;br /&gt;&lt;br /&gt;Features include: Batch editing of tags, renaming files using tags, retrieving tags from filenames, using Actions to automate repetitive tasks, importing your music library and loads of other awesome stuff. &lt;br /&gt;&lt;br /&gt;
+
+Supported formats: id3v1, id3v2 (.mp3), AAC (.mp4, .m4a), VorbisComments (.ogg, .flac) and APEv2 (.ape) &lt;br /&gt;&lt; br /&gt;
+
+Visit the puddletag website (&lt;a href=&quot;http://puddletag.sourceforge.net&quot;&gt;http://puddletag.sourceforge.net&lt;/a&gt;) for help and updates.&lt;br /&gt;&lt;br /&gt;
+&amp;copy; 2008-2012 concentricpuddle (concentricpuddle@gmail.com) &lt;br /&gt;
+Licensed under GPLv3 (&lt;a href=&quot;www.gnu.org/licenses/gpl-3.0.html&quot;&gt;www.gnu.org/licenses/gpl-3.0.html&lt;/a&gt;).
+</source>
+        <translation>puddletag är en GNU/Linux taggredigerare för ljudfiler, liknande Windows-programmet Mp3tag.
+
+&lt;br /&gt;&lt;br /&gt;Inkluderade funktioner: Massredigering av taggar, namnändring av filer med hjälp av taggar, skapa taggar från filnamn, funktioner för att automatisera repetetiva åtgärder, import av musikbibliotek och massor av andra nyttiga saker. &lt;br /&gt;&lt;br /&gt;
+
+Format som stöds: id3v1, id3v2 (.mp3), AAC (.mp4, .m4a), VorbisComments (.ogg, .flac) och APEv2 (.ape) &lt;br /&gt;&lt; br /&gt;
+
+Besök puddletags webbsidor (&lt;a href=&quot;http://puddletag.sourceforge.net&quot;&gt;http://puddletag.sourceforge.net&lt;/a&gt;) för hjälp och uppdateringar.&lt;br /&gt;&lt;br /&gt;
+&amp;copy; 2008-2012 concentricpuddle (concentricpuddle@gmail.com) &lt;br /&gt;
+Licensierad under GPLv3 (&lt;a href=&quot;www.gnu.org/licenses/gpl-3.0.html&quot;&gt;www.gnu.org/licenses/gpl-3.0.html&lt;/a&gt;)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/about.py" line="23"/>
+        <source>&lt;b&gt;Evan Devetzis&lt;/b&gt; for his many, many awesome ideas and putting up with more bugs than humanly possible.&lt;br /&gt;&lt;br /&gt;
+
+First off, a big thanks to **Evan Devetzis** for working tirelessly in helping me make puddletag better by contributing many, many awesome ideas and for being a great bug hunter.
+
+Thanks to &lt;b&gt;RaphaÃ«l Rochet&lt;/b&gt;, &lt;b&gt;Fabian Bakkum&lt;/b&gt;, &lt;b&gt;Alan Gomes&lt;/b&gt; and others for contributing translations.
+
+To the writers of the libraries puddletag depends on (without which I&apos;ll probably still be writing an id3 reader).&lt;br /&gt;&lt;br /&gt;
+
+&lt;b&gt;Paul McGuire&lt;/b&gt; for PyParsing.&lt;br /&gt;
+&lt;b&gt;Michael Urman&lt;/b&gt; and &lt;b&gt;Joe Wreschnig&lt;/b&gt; for Mutagen (It. Is. Awesome).&lt;br /&gt;
+&lt;b&gt;Phil Thomson&lt;/b&gt; and everyone responsible for PyQt4.&lt;br /&gt;
+&lt;b&gt;Michael Foord&lt;/b&gt; and &lt;b&gt;Nicola Larosa&lt;/b&gt; for ConfigObj (seriously, they should replace ConfigParser with this).&lt;br /&gt;
+The &lt;b&gt;Oxygen team&lt;/b&gt; for the Oxygen icons.
+
+</source>
+        <translation>Först, ett stort tack till **Evan Devetzis** för outtröttlig hjälp med att göra puddletag bättre genom sina många, många idéer och för bra felrapporter.
+
+Tack till &lt;b&gt;RaphaÃ«l Rochet&lt;/b&gt;, &lt;b&gt;Fabian Bakkum&lt;/b&gt;, &lt;b&gt;Alan Gomes&lt;/b&gt; och alla andra, för översättning.
+
+Till skaparna av de bibliotek puddletag är beroende av (utan vilka jag troligen fortfarande hade kodat en id3-läsare).&lt;br /&gt;&lt;br /&gt;
+
+&lt;b&gt;Paul McGuire&lt;/b&gt; för PyParsing.&lt;br /&gt;
+&lt;b&gt;Michael Urman&lt;/b&gt; och &lt;b&gt;Joe Wreschnig&lt;/b&gt; för Mutagen (It. Is. Awesome).&lt;br /&gt;
+&lt;b&gt;Phil Thomson&lt;/b&gt; och alla ansvariga för PyQt4.&lt;br /&gt;
+&lt;b&gt;Michael Foord&lt;/b&gt; och &lt;b&gt;Nicola Larosa&lt;/b&gt; för ConfigObj (seriöst, dom borde ersätta ConfigParser med det här).&lt;br /&gt;
+&lt;b&gt;Oxygen team&lt;/b&gt; för Oxygen-ikonerna.</translation>
+    </message>
+</context>
+<context>
+    <name>AcoustID</name>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="28"/>
+        <source>Calculating ID</source>
+        <translation>Beräknar ID</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="29"/>
+        <source>Retrieving AcoustID data: %1 of %2.</source>
+        <translation>Hämtar AcoustID-data: %1 av %2.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="30"/>
+        <source>Retrieving MB album data: %1</source>
+        <translation>Hämtar MB album-data: %1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="31"/>
+        <source>Error generating fingerprint: %1</source>
+        <translation>Kunde inte generera fingeravtryck: %1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="32"/>
+        <source>Error retrieving data: %1</source>
+        <translation>Kunde inte hämta data: %1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="255"/>
+        <source>Minimum Score</source>
+        <translation>Lägsta poäng</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="304"/>
+        <source>Parsing Data</source>
+        <translation>Tolkar data</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="33"/>
+        <source>Error submitting data: %1</source>
+        <translation>Fel vid sändning av data: %1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="34"/>
+        <source>Submitting data to AcoustID: %1 to %2 of %3.</source>
+        <translation>Sänder data till AcoustID: %1 till %2 av %3.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="35"/>
+        <source>Found AcoustID in file.</source>
+        <translation>Hittade AcoustID i fil.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="36"/>
+        <source>File #%1: %2</source>
+        <translation>Fil #%1: %2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="256"/>
+        <source>AcoustID Key</source>
+        <translation>AcoustID-nyckel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/acoust_id.py" line="330"/>
+        <source>Please enter AcoustID user key in settings.</source>
+        <translation>Ange AcoustID användarnyckel i inställningar.</translation>
+    </message>
+</context>
+<context>
+    <name>Actions</name>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="99"/>
+        <source>Enter a name for the shortcut.</source>
+        <translation>Ange ett namn för genvägen.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="522"/>
+        <source>Error: Using &lt;b&gt;__selected&lt;/b&gt; in Actions is not allowed.</source>
+        <translation>Fel: Användning av &lt;b&gt;__selected&lt;/b&gt; i Åtgärder, är inte tillåtet.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="528"/>
+        <source>Please enter some fields to write to.</source>
+        <translation>Ange några fält att skriva till.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="566"/>
+        <source>Modify Action</source>
+        <translation>Ändra Åtgärden</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="694"/>
+        <source>Actions</source>
+        <translation>Åtgärder</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="720"/>
+        <source>Assign &amp;Shortcut</source>
+        <translation>Tilldela &amp;genväg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="723"/>
+        <source>&lt;p&gt;Creates a
+            shortcut for the checked actions on the Actions menu.
+            Use Edit Shortcuts (found by pressing down on this button)
+            to edit shortcuts after the fact.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Skapar en
+............genväg för den markerade åtgärden i menyn Åtgärder.
+............Använd &apos;Redigera åtgärd&apos; för att redigera åtgärder.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="728"/>
+        <source>Edit Shortcuts</source>
+        <translation>Redigera åtgärder</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="953"/>
+        <source>New Action</source>
+        <translation>Ny åtgärd</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="1044"/>
+        <source>Enter a name for the new action.</source>
+        <translation>Ange ett namn för den nya åtgärden.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="966"/>
+        <source>Add Action: </source>
+        <translation>Lägg till åtgärd: </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="984"/>
+        <source>Edit Action: </source>
+        <translation>Rdeigera åtgärd: </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="1055"/>
+        <source>Edit Action: %s</source>
+        <translation>Redigera åtgärd: %s</translation>
+    </message>
+</context>
+<context>
+    <name>Amazon</name>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="66"/>
+        <source>Invalid Access or Secret Key</source>
+        <translation>Ogilltig åtkomst- eller säkerhetsnyckel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="111"/>
+        <source>Retrieving search results for keywords: %s</source>
+        <translation>Hämtar sökresultat för nyckelord: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="136"/>
+        <source>Invalid XML returned. No tracks listed.</source>
+        <translation>Ogiltig XML returnerades. Inga spår listade.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="181"/>
+        <source>%s at Amazon.com</source>
+        <translation>%s på Amazon.com</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="206"/>
+        <source>Retrieving using ASIN: %s</source>
+        <translation>Hämtar med hjälp av ASIN: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="209"/>
+        <source>Retrieving XML: %1 - %2</source>
+        <translation>Hämtar XML: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="221"/>
+        <source>Retrieving cover: %s</source>
+        <translation>Hämtar omslag: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="277"/>
+        <source>&lt;p&gt;Enter search parameters here. If empty, the selected files
+        are used.&lt;/p&gt;
+        &lt;ul&gt;
+        &lt;li&gt;&lt;b&gt;artist;album&lt;/b&gt;
+        searches for a specific album/artist combination.&lt;/li&gt;
+        &lt;li&gt;To list the albums by an artist leave off the album part,
+        but keep the semicolon (eg. &lt;b&gt;Ratatat;&lt;/b&gt;).
+        For a album only leave the artist part as in
+        &lt;b&gt;;Resurrection.&lt;/li&gt;
+        &lt;li&gt;Entering keywords &lt;b&gt;without a semi-colon (;)&lt;/b&gt; will do an
+        Amazon album search using those keywords.&lt;/li&gt;
+        &lt;/ul&gt;</source>
+        <translation>&lt;p&gt;Ange sökparametrar här. Lämnas tom, för användning av
+........markerade filer.&lt;/p&gt;
+        &lt;ul&gt;
+        &lt;li&gt;&lt;b&gt;artist;album&lt;/b&gt;
+........söker en specifik album-/artistkombination.&lt;/li&gt;
+        &lt;li&gt;För att lista en artists album utelämnas albumdelen,
+        men lämna kvar semikolon (exempel: &lt;b&gt;Lolita Pop;&lt;/b&gt;).
+        För endast album, lämna artistdelen som i 
+        &lt;b&gt;;Love Poison
+        &lt;li&gt;Nyckelord&lt;b&gt;utan semikolon (;)&lt;/b&gt; utför en albumsökning
+        på Amazon med exakt de nyckelorden.&lt;/li&gt;
+        &lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="326"/>
+        <source>Retrieve Cover</source>
+        <translation>Hämta omslag</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="327"/>
+        <source>Cover size to retrieve</source>
+        <translation>Omslagsstorlek att hämta</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="481"/>
+        <source>Small</source>
+        <translation>Liten</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="329"/>
+        <source>Medium</source>
+        <translation>Medium</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="482"/>
+        <source>Large</source>
+        <translation>Stor</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="331"/>
+        <source>Access Key (Stored as plain-text. Leave empty for default.)</source>
+        <translation>Åtkomstnyckel (Lagras som oformaterad text. Lämnas tom för standard.)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/amazon.py" line="333"/>
+        <source>Secret Key (Stored as plain-text. Leave empty for default.)</source>
+        <translation>Säkerhetsnyckel (Lagras som oformaterad text. Lämnas tom för standard.)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="483"/>
+        <source>Original Size</source>
+        <translation>Ursprunglig storlek</translation>
+    </message>
+</context>
+<context>
+    <name>Artwork</name>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1816"/>
+        <source>Enter a description</source>
+        <translation>Ange en beskrivning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1528"/>
+        <source>&lt;p&gt;Enter a description for the current cover.&lt;/p&gt;&lt;p&gt;For ID3 tags the description has to be different for each cover as per the ID3 spec. If they don&apos;t differ then spaces are appended to the description when the tag is saved.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Ange en beskrivning för aktuellt omslag&lt;/p&gt;&lt;/p&gt;För ID3-taggar, måste beskrivningen vara unik för varje omslag, enligt ID3-specifikationen. Om de inte skiljer sig åt, kommer blanksteg att läggas till i beskrivningen, när den sparas.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1540"/>
+        <source>&amp;Description</source>
+        <translation>&amp;Beskrivning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1548"/>
+        <source>&amp;Type</source>
+        <translation>&amp;Typ</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1559"/>
+        <source>&lt;p&gt;Select a cover type for the artwork.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Välj en omslagstyp för albumbilden.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1638"/>
+        <source>&amp;Save cover to file</source>
+        <translation>&amp;Spara omslag till fil</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1641"/>
+        <source>&amp;Add cover</source>
+        <translation>&amp;Lägg till omslag</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1644"/>
+        <source>&amp;Remove cover</source>
+        <translation>Ta b&amp;ort omslag</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1647"/>
+        <source>&amp;Change cover</source>
+        <translation>B&amp;yt omslag</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1709"/>
+        <source>Select Image...</source>
+        <translation>Välj bild...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1868"/>
+        <source>JPEG Images (*.jpg);;PNG Images (*.png);;All Files(*.*)</source>
+        <translation>JPEG-bilder (*.jpg);;PNG-bilder (*.png);;Alla filer(*.*)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1868"/>
+        <source>Save artwork as...</source>
+        <translation>Spara albumbild som...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1876"/>
+        <source>Writing to &lt;b&gt;%1&lt;/b&gt; failed.</source>
+        <translation>Kunde inte skriva till &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1952"/>
+        <source>Enter description</source>
+        <translation>Ange beskrivning</translation>
+    </message>
+</context>
+<context>
+    <name>Artwork Context</name>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1500"/>
+        <source>%1/%2</source>
+        <translation>%1/%2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="67"/>
+        <source>Cover Varies</source>
+        <translation>Varierande omslag</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="68"/>
+        <source>No Images</source>
+        <translation>Inga bilder</translation>
+    </message>
+</context>
+<context>
+    <name>Autonumbering Wizard</name>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="54"/>
+        <source>&amp;Start: </source>
+        <translation>&amp;Start: </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="64"/>
+        <source>Max length after padding with zeroes: </source>
+        <translation>Maxlängd efter utfyllnad med nollor: </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="76"/>
+        <source>&amp;Restart numbering at each directory.</source>
+        <translation>Starta &amp;om numrering i varje mapp.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="38"/>
+        <source>Autonumbering Wizard</source>
+        <translation>Autonumreringsguide</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="104"/>
+        <source>Add track &amp;separator [&apos;/&apos;]: Number of tracks</source>
+        <translation>Lägg till &amp;spårseparator [&apos;/&apos;]: Antal spår</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="100"/>
+        <source>Add track &amp;separator [&apos;/&apos;]</source>
+        <translation>Lägg till &amp;spårseparator [&apos;/&apos;]</translation>
+    </message>
+</context>
+<context>
+    <name>Colour Settings</name>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="535"/>
+        <source>&lt;p&gt;Below are the backgrounds used for various controls in puddletag. &lt;br /&gt; Double click the desired action to change its colour.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Här är de bakgrunder som avänds för diverse kontroller i puddletag.&lt;br /&gt;Dubbelklicka på önskad åtgärd för att ändra dess färg&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="548"/>
+        <source>Row selected in file-view.</source>
+        <translation>Markerad rad i filvyn.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="549"/>
+        <source>Row colour for files with previews.</source>
+        <translation>Radfärg för filer med förhandsgranskning.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="550"/>
+        <source>Field added in Extended Tags.</source>
+        <translation>Tillagda fält i utökade taggar.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="551"/>
+        <source>Field edited in Extended Tags.</source>
+        <translation>Redigerat fält i utökade taggar.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="552"/>
+        <source>Field removed in Extended Tags.</source>
+        <translation>Bortaget fält i utökade taggar.</translation>
+    </message>
+</context>
+<context>
+    <name>Column Settings</name>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="934"/>
+        <source>Title</source>
+        <translation>Titel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="362"/>
+        <source>Columns</source>
+        <translation>Kolumner</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="392"/>
+        <source>Adjust visibility of columns.</source>
+        <translation>Justera synlighet för kolumner.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1268"/>
+        <source>&amp;Select Columns</source>
+        <translation>&amp;Välj kolumner</translation>
+    </message>
+</context>
+<context>
+    <name>Combo Box</name>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="2110"/>
+        <source>Remove current item.</source>
+        <translation>Ta bort aktuellt objekt.</translation>
+    </message>
+</context>
+<context>
+    <name>Confirmations</name>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="61"/>
+        <source>Confirm when exiting preview mode.</source>
+        <translation>Bekräfta avslut av förhandsvisningsläge.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="62"/>
+        <source>Confirm when deleting files.</source>
+        <translation>Bekräfta borttagning av filer.</translation>
+    </message>
+</context>
+<context>
+    <name>Cover Type</name>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="147"/>
+        <source>Other</source>
+        <translation>Annat</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="147"/>
+        <source>O</source>
+        <translation>An</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="148"/>
+        <source>File Icon</source>
+        <translation>Filikon</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="148"/>
+        <source>I</source>
+        <translation>I</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="149"/>
+        <source>Other File Icon</source>
+        <translation>Annan filikon</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="149"/>
+        <source>OI</source>
+        <translation>Af</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="150"/>
+        <source>Cover (front)</source>
+        <translation>Omslag (fram)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="150"/>
+        <source>CF</source>
+        <translation>Of</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="151"/>
+        <source>Cover (back)</source>
+        <translation>Omslag (bak)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="151"/>
+        <source>CB</source>
+        <translation>Ob</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="152"/>
+        <source>Leaflet page</source>
+        <translation>Broschyrsida</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="152"/>
+        <source>LF</source>
+        <translation>Bs</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="153"/>
+        <source>Media (e.g. label side of CD)</source>
+        <translation>Media (ex. etikettsida för CD)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="153"/>
+        <source>M</source>
+        <translation>M</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="154"/>
+        <source>Lead artist</source>
+        <translation>Vokalist</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="154"/>
+        <source>LA</source>
+        <translation>V</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="155"/>
+        <source>Artist</source>
+        <translation>Artist</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="155"/>
+        <source>A</source>
+        <translation>A</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="156"/>
+        <source>Conductor</source>
+        <translation>Dirigent</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="156"/>
+        <source>C</source>
+        <translation>D</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="157"/>
+        <source>Band</source>
+        <translation>Band</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="157"/>
+        <source>B</source>
+        <translation>B</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="158"/>
+        <source>Composer</source>
+        <translation>Kompositör</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="158"/>
+        <source>CP</source>
+        <translation>K</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="159"/>
+        <source>Lyricist</source>
+        <translation>Textförfattare</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="159"/>
+        <source>L</source>
+        <translation>T</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="160"/>
+        <source>Recording Location</source>
+        <translation>Inspelningsplats</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="160"/>
+        <source>RL</source>
+        <translation>Ip</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="161"/>
+        <source>During recording</source>
+        <translation>Under inspelning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="161"/>
+        <source>DR</source>
+        <translation>Ui</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="162"/>
+        <source>During performance</source>
+        <translation>Under uppträdande</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="162"/>
+        <source>DP</source>
+        <translation>Uu</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="163"/>
+        <source>Movie/video screen capture</source>
+        <translation>Film-/Video-skärmklipp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="163"/>
+        <source>MC</source>
+        <translation>Sk</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="164"/>
+        <source>A bright coloured fish</source>
+        <translation>En ljusfärgad fisk</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="164"/>
+        <source>F</source>
+        <translation>F</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="165"/>
+        <source>Illustration</source>
+        <translation>Illustration</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="165"/>
+        <source>P</source>
+        <translation>Il</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="166"/>
+        <source>Band/artist logotype</source>
+        <translation>Band-/Artistlogo</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="166"/>
+        <source>BL</source>
+        <translation>Bl</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="167"/>
+        <source>Publisher/Studio logotype</source>
+        <translation>Utgivar-/Studiologo</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="167"/>
+        <source>PL</source>
+        <translation>Ul</translation>
+    </message>
+</context>
+<context>
+    <name>Defaults</name>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="147"/>
+        <source>&amp;Fields</source>
+        <translation>&amp;Fält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/constants.py" line="29"/>
+        <source>Yes</source>
+        <translation>Ja</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/funcs.py" line="149"/>
+        <source>No</source>
+        <translation>Nej</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/constants.py" line="31"/>
+        <source>&lt;blank&gt;</source>
+        <translation>&lt;tom&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/constants.py" line="32"/>
+        <source>&lt;keep&gt;</source>
+        <translation>&lt;behåll&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/constants.py" line="12"/>
+        <source>Various</source>
+        <translation>Diverse</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/constants.py" line="34"/>
+        <source>MusicBrainz</source>
+        <translation>MusicBrainz</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/constants.py" line="35"/>
+        <source>SYNTAX ERROR in $%1: %2</source>
+        <translation>SYNTAXFEL i $%1: %2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/constants.py" line="36"/>
+        <source>SYNTAX ERROR: %s expects a number at argument %d.</source>
+        <translation>SYNTAXFEL: %s förväntar sig en siffra i argument %d.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/constants.py" line="33"/>
+        <source>Various Artists</source>
+        <translation>Diverse artister</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/findfunc.py" line="287"/>
+        <source>function does not exist.</source>
+        <translation>Åtgärden finns inte.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/action_dialogs.py" line="82"/>
+        <source>Appl&amp;y</source>
+        <translation>Till&amp;ämpa</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/filterwin.py" line="42"/>
+        <source>Filter: </source>
+        <translation>Filter: </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/filterwin.py" line="43"/>
+        <source>Go</source>
+        <translation>Kör</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/tagpanel.py" line="417"/>
+        <source>Title</source>
+        <translation>Titel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="936"/>
+        <source>Field</source>
+        <translation>Fält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/tagtools.py" line="57"/>
+        <source>An error occured while writing to &lt;b&gt;%1&lt;/b&gt;. (%2)</source>
+        <translation>Ett fel inträffade vid skrivning till &lt;b&gt;%1&lt;/b&gt;. (%2)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="389"/>
+        <source>Fields: </source>
+        <translation>Fält:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1984"/>
+        <source>Error</source>
+        <translation>Fel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="484"/>
+        <source>&lt;br /&gt; Do you want to continue?</source>
+        <translation>&lt;br /&gt; Vill du fortsätta?</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1352"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="2045"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="800"/>
+        <source>Writing </source>
+        <translation>Skriver </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1587"/>
+        <source>&amp;Yes</source>
+        <translation>&amp;Ja</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1587"/>
+        <source>&amp;No</source>
+        <translation>&amp;Nej</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1818"/>
+        <source>Reading Directory: %1</source>
+        <translation>Inläsningsmapp: %1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1821"/>
+        <source>Reading Directory: %1 + others</source>
+        <translation>Inläsningsmapp: %1 + andra</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1824"/>
+        <source>Reading Dir</source>
+        <translation>Inläsningsmapp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1850"/>
+        <source>Loading </source>
+        <translation>Läser in</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/util.py" line="30"/>
+        <source>&lt;p&gt;An error occured while renaming the directory &lt;b&gt;%1&lt;/b&gt; to &lt;i&gt;%2&lt;/i&gt;.&lt;/p&gt;&lt;p&gt;Reason: &lt;b&gt;%3&lt;/b&gt;&lt;br /&gt;File used: %4&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Ett fel inträffade vid namnbyte av mappen &lt;b&gt;%1&lt;/b&gt; till &lt;i&gt;%2&lt;/i&gt;.&lt;/p&gt;&lt;p&gt;Orsak: &lt;b&gt;%3&lt;/b&gt;&lt;br /&gt;Fil som används: %4&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/util.py" line="39"/>
+        <source>&lt;p&gt;An error occured while renaming the file &lt;b&gt;%1&lt;/b&gt; to &lt;i&gt;%2&lt;/i&gt;.&lt;/p&gt;&lt;p&gt;Reason: &lt;b&gt;%3&lt;/b&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Ett fel inträffade vid namnbyte av filen &lt;b&gt;%1&lt;/b&gt; till &lt;i&gt;%2&lt;/i&gt;.&lt;/p&gt;&lt;p&gt;Orsak: &lt;b&gt;%3&lt;/b&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/util.py" line="45"/>
+        <source>&lt;p&gt;An error occured while writing to &lt;b&gt;%1&lt;/b&gt;.&lt;/p&gt;&lt;p&gt;Reason: &lt;b&gt;%2&lt;/b&gt; (&lt;i&gt;See ~/.puddletag/log.log for debug info.&lt;/i&gt;)&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Ett fel inträffade vid skrivning till &lt;b&gt;%1&lt;/b&gt;.&lt;/p&gt;&lt;p&gt;Orsak: &lt;b&gt;%2&lt;/b&gt; (&lt;i&gt;Se ~/.puddletag/log.log för felsökningsinfo.&lt;/i&gt;)&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/util.py" line="144"/>
+        <source>%s images</source>
+        <translation>%s bilder</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="359"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Redigera</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="1071"/>
+        <source>Never show this message again.</source>
+        <translation>Visa inte det här meddelandet igen.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/__init__.py" line="165"/>
+        <source>Connection Error: %s </source>
+        <translation>Anslutningsfel: %s </translation>
+    </message>
+</context>
+<context>
+    <name>Dialogs</name>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1990"/>
+        <source>Album Art</source>
+        <translation>Albumomslag</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="250"/>
+        <source>Tag Panel</source>
+        <translation>Taggpanel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="251"/>
+        <source>Artwork</source>
+        <translation>Omslagsbild</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="252"/>
+        <source>Filesystem</source>
+        <translation>Filsystem</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="253"/>
+        <source>Filter</source>
+        <translation>Filter</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="254"/>
+        <source>Tag Sources</source>
+        <translation>Taggkällor</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="255"/>
+        <source>Stored Tags</source>
+        <translation>Lagrade taggar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="256"/>
+        <source>Logs</source>
+        <translation>Loggar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="257"/>
+        <source>Mass Tagging</source>
+        <translation>Masstaggning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="258"/>
+        <source>Functions</source>
+        <translation>Funktioner</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="259"/>
+        <source>Actions</source>
+        <translation>Åtgärder</translation>
+    </message>
+</context>
+<context>
+    <name>Dir Renaming</name>
+    <message>
+        <location filename="puddlestuff/mainwin/funcs.py" line="502"/>
+        <source>Rename: &lt;b&gt;%1&lt;/b&gt; to: &lt;i&gt;%2&lt;/i&gt;</source>
+        <translation>Byt namn på &lt;b&gt;%1&lt;/b&gt; till &lt;i&gt;%2&lt;/i&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="880"/>
+        <source>An error occured while renaming &lt;b&gt;%1&lt;/b&gt; to &lt;b&gt;%2&lt;/b&gt;. (%3)</source>
+        <translation>Ett fel inträffade vid namnbyte från &lt;b&gt;%1&lt;/b&gt; till &lt;b&gt;%2&lt;/b&gt;. (%3)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="888"/>
+        <source>Renaming </source>
+        <translation>Byter namn på </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="904"/>
+        <source>I couldn&apos;t rename: &lt;i&gt;%1&lt;/i&gt; to &lt;b&gt;%2&lt;/b&gt; (%3)</source>
+        <translation>Kunde inte byta namn på &lt;i&gt;%1&lt;/i&gt; till &lt;b&gt;%2&lt;/b&gt; (%3)</translation>
+    </message>
+</context>
+<context>
+    <name>Dirview</name>
+    <message>
+        <location filename="puddlestuff/mainwin/dirview.py" line="89"/>
+        <source>Refresh Directory</source>
+        <translation>Uppdatera mappen</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/dirview.py" line="97"/>
+        <source>Show Header</source>
+        <translation>Visa huvud</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/dirview.py" line="101"/>
+        <source>Hide Header</source>
+        <translation>Dölj huvud</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/dirview.py" line="105"/>
+        <source>Open in File Manager</source>
+        <translation>Öppna i filhanteraren</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/dirview.py" line="316"/>
+        <source>Subfolders</source>
+        <translation>Undermappar</translation>
+    </message>
+</context>
+<context>
+    <name>Discogs</name>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="98"/>
+        <source>Retrieving search results for keywords: %s</source>
+        <translation>Hämtar sökresultat för nyckelord: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="275"/>
+        <source>%s at Discogs.com</source>
+        <translation>%s på Discogs.com</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="232"/>
+        <source>Retrieving using Release ID: %s</source>
+        <translation>Hämtar med hjälp av Utgivnings-ID: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="239"/>
+        <source>Retrieving album %s</source>
+        <translation>Hämtar album %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="264"/>
+        <source>Retrieving cover: %s</source>
+        <translation>Hämtar omslag: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="269"/>
+        <source>Error retrieving image:</source>
+        <translation>Kunde inte hämta bild:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="324"/>
+        <source>&lt;p&gt;Enter search parameters here. If empty,
+        the selected files are used.&lt;/p&gt;
+        &lt;ul&gt;
+        &lt;li&gt;&lt;b&gt;artist;album&lt;/b&gt;
+        searches for a specific album/artist combination.&lt;/li&gt;
+        &lt;li&gt;To list the albums by an artist leave off the album part,
+        but keep the semicolon (eg. &lt;b&gt;Ratatat;&lt;/b&gt;).
+        For a album only leave the artist part as in
+        &lt;b&gt;;Resurrection.&lt;/li&gt;
+        &lt;li&gt;Using &lt;b&gt;:r id&lt;/b&gt; will retrieve the album with Discogs
+        ID &lt;b&gt;id&lt;/b&gt;.&lt;/li&gt;
+        &lt;li&gt;Entering keywords &lt;b&gt;without a semi-colon (;)&lt;/b&gt; will
+         do a Discogs album search using those keywords.&lt;/li&gt;
+        &lt;/ul&gt;</source>
+        <translation>&lt;p&gt;Ange sökparametrar här. Lämnas tom, för användning av
+........markerade filer.&lt;/p&gt;
+        &lt;ul&gt;
+        &lt;li&gt;&lt;b&gt;artist;album&lt;/b&gt;
+........söker en specifik album-/artistkombination.&lt;/li&gt;
+        &lt;li&gt;För att lista en artists album utelämnas albumdelen,
+        men lämna kvar semikolon (exempel: &lt;b&gt;Lolita Pop;&lt;/b&gt;).
+        För endast album, lämna artistdelen som i 
+        &lt;b&gt;;Love Poisoon.&lt;/li&gt;
+        &lt;li&gt;Används&lt;b&gt;:r id&lt;/b&gt; hämtas albumet med Discogs
+        ID &lt;b&gt;id&lt;/b&gt;.&lt;/li&gt;
+        &lt;li&gt;Nyckelord&lt;b&gt;utan semikolon (;)&lt;/b&gt; utför en albumsökning
+        på Discogs med exakt de nyckelorden.&lt;/li&gt;
+        &lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="345"/>
+        <source>Retrieve Cover</source>
+        <translation>Hämta omslag</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="346"/>
+        <source>Cover size to retrieve</source>
+        <translation>Omslagsstorlek att hämta</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="347"/>
+        <source>Small</source>
+        <translation>Liten</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="348"/>
+        <source>Large</source>
+        <translation>Stor</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="349"/>
+        <source>Field to use for discogs_id</source>
+        <translation>Fält att använda för discogs_id</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="350"/>
+        <source>API Key (Stored as plain-text.Leave empty to use default.)</source>
+        <translation>API-nyckel (Lagras som oformaterad text. Lämnas tom för standard.)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="362"/>
+        <source>Invalid Discogs Release ID</source>
+        <translation>Ogiltigt Discogs utgivnings-ID</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="381"/>
+        <source>Checking tracks for Discogs Album ID.</source>
+        <translation>Kontrollerar spår efter Discogs album-ID.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="387"/>
+        <source>No Discogs ID found in tracks.</source>
+        <translation>Inget Discogs-ID hittades i spåren.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/discogs.py" line="390"/>
+        <source>Found Discogs ID: %s</source>
+        <translation>Discogs-ID hittat: %s</translation>
+    </message>
+</context>
+<context>
+    <name>Edit Field</name>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="320"/>
+        <source>Edit Field</source>
+        <translation>Redigera fält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="325"/>
+        <source>&amp;Field</source>
+        <translation>&amp;Fält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="337"/>
+        <source>&amp;Value</source>
+        <translation>&amp;Värde</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="343"/>
+        <source>A&amp;dd</source>
+        <translation>&amp;Lägg till</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="354"/>
+        <source>E&amp;dit</source>
+        <translation>&amp;Redigera</translation>
+    </message>
+</context>
+<context>
+    <name>Errors</name>
+    <message>
+        <location filename="puddlestuff/findfunc.py" line="364"/>
+        <source>No closing bracket found.</source>
+        <translation>Ingen slutklammer hittades.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/util.py" line="65"/>
+        <source>Couldn&apos;t create intermediate directory: %s</source>
+        <translation>Kunde inte skapa mellanliggande mapp: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/util.py" line="83"/>
+        <source>Cannot move directory to a subdirectory within itself.</source>
+        <translation>Kan inte flytta mapp till undermapp inne i sig själv.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="649"/>
+        <source>Your filesystem encoding was detected as &lt;b&gt;ASCII&lt;/b&gt;. &lt;br /&gt;You won&apos;t be able to rename files using accented, &lt;br /&gt; cyrillic or any characters outside the ASCII alphabet.</source>
+        <translation>Ditt filsystems teckentabell uppfattas som &lt;b&gt;ASCII&lt;/b&gt;. &lt;br /&gt;Du kommer inte att kunna byta namn på filer med accent, kyrilliska eller några andra tecken utanför ASCII-alfabetet.</translation>
+    </message>
+</context>
+<context>
+    <name>Extended Tags</name>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="553"/>
+        <source>Field</source>
+        <translation>Fält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="553"/>
+        <source>Value</source>
+        <translation>Värde</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="588"/>
+        <source>Resets the selected fields to their original value.</source>
+        <translation>Återställ markerade fält till ursprungliga värden.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="821"/>
+        <source>Different files.</source>
+        <translation>Olika filer.</translation>
+    </message>
+</context>
+<context>
+    <name>Fields</name>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Filename</source>
+        <translation>Filnamn</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Artist</source>
+        <translation>Artist</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Title</source>
+        <translation>Titel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Album</source>
+        <translation>Album</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Track</source>
+        <translation>Spår</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Length</source>
+        <translation>Längd</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Year</source>
+        <translation>År</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Bitrate</source>
+        <translation>Bithastighet</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Genre</source>
+        <translation>Genre</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Comment</source>
+        <translation>Kommentar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="63"/>
+        <source>Dirpath</source>
+        <translation>Mappsökväg</translation>
+    </message>
+</context>
+<context>
+    <name>FreeDB</name>
+    <message>
+        <location filename="puddlestuff/tagsources/freedb.py" line="161"/>
+        <source>&lt;b&gt;FreeDB does not support text-based searches.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;FreeDB stödjer inte textbaserade sökningar.&lt;/b&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>Functions</name>
+    <message>
+        <location filename="puddlestuff/findfunc.py" line="48"/>
+        <source>At most %1 arguments expected. %2 given.</source>
+        <translation>Som mest %1 argument förväntades. %2 angavs.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/findfunc.py" line="54"/>
+        <source>At least %1 arguments expected. %2 given.</source>
+        <translation>Minst %1 argument förväntades. %2 angavs.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="147"/>
+        <source>Tag-&gt;File: $1</source>
+        <translation>Tagg-&gt;Fil: $1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="148"/>
+        <source>Tag to filename</source>
+        <translation>Tagg till filnamn</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="247"/>
+        <source>&amp;Pattern</source>
+        <translation>&amp;Mönster</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="150"/>
+        <source>Replace $0: &apos;$1&apos; -&gt; &apos;$2&apos;, Match Case: $3, Words Only: $4</source>
+        <translation>Ersätt $0: &apos;$1&apos; -&gt; &apos;$2&apos;, Skiftläge: $3, Endast ord: $4</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="151"/>
+        <source>Replace</source>
+        <translation>Ersätt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="152"/>
+        <source>&amp;Replace</source>
+        <translation>&amp;Ersätt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="153"/>
+        <source>w&amp;ith:</source>
+        <translation>me&amp;d:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="154"/>
+        <source>Match c&amp;ase:</source>
+        <translation>Skift&amp;läge:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="155"/>
+        <source>only as &amp;whole word</source>
+        <translation>endast som &amp;hela ord</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="156"/>
+        <source>Update from $2, Fields: $1</source>
+        <translation>Uppdatera från $2, Fält: $1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="157"/>
+        <source>Update from tag</source>
+        <translation>Uppdatera från tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="212"/>
+        <source>&amp;Field list (; separated):</source>
+        <translation>&amp;Fältlista (semikolonseparerad):</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="159"/>
+        <source>&amp;Tag</source>
+        <translation>&amp;Tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="160"/>
+        <source>APEv2</source>
+        <translation>APEv2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="161"/>
+        <source>ID3</source>
+        <translation>ID3</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="162"/>
+        <source>Trim $0</source>
+        <translation>Trimma $0</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="163"/>
+        <source>Trim whitespace</source>
+        <translation>Trimma blanksteg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="164"/>
+        <source>RegReplace $0: RegExp &apos;$1&apos; with &apos;$2&apos;, Match Case: $3</source>
+        <translation>RegReplace $0: RegExp &apos;$1&apos; med &apos;$2&apos;, Skiftläge: $3</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="165"/>
+        <source>Replace with RegExp</source>
+        <translation>Ersätt med RegExp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="166"/>
+        <source>&amp;Regular Expression</source>
+        <translation>&amp;Regular Expression</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="167"/>
+        <source>Replace &amp;matches with:</source>
+        <translation>Ersätt &amp;sökträffar med:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="205"/>
+        <source>Match &amp;Case</source>
+        <translation>Skift&amp;läge</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="169"/>
+        <source>Export Art: pattern=&apos;$1&apos;</source>
+        <translation>Exportera bilder: mönster=&apos;$1&apos;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="170"/>
+        <source>Export artwork to file</source>
+        <translation>Exportera albumbilder till fil</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="171"/>
+        <source>&amp;Pattern (extension not required)</source>
+        <translation>&amp;Mönster (filformat behövs inte)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="172"/>
+        <source>folder_%img_counter%</source>
+        <translation>folder_%img_counter%</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="173"/>
+        <source>Autonumbering: $0, Start: $1, Restart for dir: $2, Padding: $3</source>
+        <translation>Autonumrering: $0, Start: $1, Omstart för mapp: $2, Utfyllnad: $3</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="174"/>
+        <source>Autonumbering</source>
+        <translation>Autonumrering</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="175"/>
+        <source>oi</source>
+        <translation>oi</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="180"/>
+        <source>1</source>
+        <translation>1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="177"/>
+        <source>aoeu</source>
+        <translation>aoeu</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="178"/>
+        <source>False</source>
+        <translation>Falsk</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="179"/>
+        <source>au</source>
+        <translation>Padding</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="181"/>
+        <source>Sort $0, order=&apos;$1&apos;, Match Case=&apos;$2&apos;</source>
+        <translation>Sortera $0, ordna=&apos;$1&apos;, Skiftläge=&apos;$2&apos;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="182"/>
+        <source>Sort values</source>
+        <translation>Sortera värden</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="183"/>
+        <source>&amp;Order</source>
+        <translation>&amp;Ordna</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="184"/>
+        <source>Ascending</source>
+        <translation>Stigande</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="185"/>
+        <source>Descending</source>
+        <translation>Fallande</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="187"/>
+        <source>Tag-&gt;Dir: $1</source>
+        <translation>Tagg-&gt;Mapp: $1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="188"/>
+        <source>Tag to Dir</source>
+        <translation>Tagg till mapp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="208"/>
+        <source>&amp;Pattern (can be relative path)</source>
+        <translation>&amp;Mönster (kan vara relativ sökväg)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="190"/>
+        <source>%artist% - %album%</source>
+        <translation>%artist% - %album%</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="191"/>
+        <source>Format $0 using $1</source>
+        <translation>Format $0 med hjälp av $1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="192"/>
+        <source>Format value</source>
+        <translation>Formatvärde</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="193"/>
+        <source>&amp;Format string</source>
+        <translation>&amp;Formatsträng</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="194"/>
+        <source>Artwork: Filenames=&apos;$1&apos;, Description=&apos;$2&apos;, Case Sensitive=$3</source>
+        <translation>Albumbilder: Filnamn=&apos;$1&apos;, Beskrivning=&apos;$2&apos;, Skiftlägeskänslig=$3</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="195"/>
+        <source>Load Artwork</source>
+        <translation>Läs in albumbilder</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="196"/>
+        <source>&amp;Filenames to check (;-separated, shell wildcards [eg. *] allowed)</source>
+        <translation>&amp;Filnamn att kontrollera (semikolonseparerade, jokertecken * tillåtet)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="197"/>
+        <source>&amp;Default description (can be pattern):</source>
+        <translation>&amp;Standardbeskrivning (kan vara mönster):</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="198"/>
+        <source>Match filename&apos;s &amp;case:</source>
+        <translation>Matcha filnamns skift&amp;läge:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="199"/>
+        <source>Merge field: $0, sep=&apos;$1&apos;</source>
+        <translation>Sammanfoga fält: $0, sep=&apos;$1&apos;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="200"/>
+        <source>Merge field</source>
+        <translation>Sammanfoga fält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="243"/>
+        <source>&amp;Separator</source>
+        <translation>&amp;Separator</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="244"/>
+        <source>;</source>
+        <translation>;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="203"/>
+        <source>Remove Dupes: $0, Match Case $1</source>
+        <translation>Ta bort dubbletter: $0, Skiftläge $1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="204"/>
+        <source>Remove duplicate values</source>
+        <translation>Ta bort dubblettvärden</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="206"/>
+        <source>Text File: $0, &apos;$1&apos;</source>
+        <translation>Textfil: $0, &apos;$1&apos;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="207"/>
+        <source>Import text file</source>
+        <translation>Importera textfil</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="209"/>
+        <source>lyrics.txt</source>
+        <translation>texter.txt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="210"/>
+        <source>Remove fields except: $1</source>
+        <translation>Ta bort fält utom: $1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="211"/>
+        <source>Remove all fields except</source>
+        <translation>Ta bort alla fält utom</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="214"/>
+        <source>&lt;blank&gt; $0</source>
+        <translation>&lt;tom&gt; $0</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="215"/>
+        <source>Remove Fields</source>
+        <translation>Ta bort fält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="216"/>
+        <source>Convert Case: $0: $1</source>
+        <translation>Konvertera skiftläge: $0 - $1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="217"/>
+        <source>Case conversion</source>
+        <translation>Skiftlägeskonvertering</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="218"/>
+        <source>&amp;Type</source>
+        <translation>&amp;Typ</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="219"/>
+        <source>Mixed Case</source>
+        <translation>Blandat skiftläge</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="220"/>
+        <source>UPPER CASE</source>
+        <translation>VERSALER</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="221"/>
+        <source>lower case</source>
+        <translation>gemener</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="222"/>
+        <source>For &amp;Mixed Case, after any of:</source>
+        <translation>För &amp;blandat skiftäge, efter vilket som helst av:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="223"/>
+        <source>., !</source>
+        <translation>., !</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="224"/>
+        <source>Convert to encoding: $0, Encoding: $1</source>
+        <translation>Konvertera till teckentabell: $0, Kodning: $1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="225"/>
+        <source>Convert from non-standard encoding</source>
+        <translation>Konvertera från icke standardkodning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="226"/>
+        <source>&amp;Encoding</source>
+        <translation>&amp;Kodning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="227"/>
+        <source>cp1250</source>
+        <translation>cp1250</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="228"/>
+        <source>cp1251</source>
+        <translation>cp1251</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="229"/>
+        <source>cp1252</source>
+        <translation>cp1252</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="230"/>
+        <source>cp1253</source>
+        <translation>cp1253</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="231"/>
+        <source>cp1254</source>
+        <translation>cp1254</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="232"/>
+        <source>cp1255</source>
+        <translation>cp1255</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="233"/>
+        <source>cp1256</source>
+        <translation>cp1256</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="234"/>
+        <source>cp1257</source>
+        <translation>cp1257</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="235"/>
+        <source>cp1258</source>
+        <translation>cp1258</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="236"/>
+        <source>Text to Tag: $0 -&gt; $1, $2</source>
+        <translation>Text till tagg: $0 -&gt; $1, $2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="237"/>
+        <source>Text to Tag</source>
+        <translation>Text till tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="238"/>
+        <source>&amp;Text</source>
+        <translation>&amp;Text</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="240"/>
+        <source>&amp;Output</source>
+        <translation>&amp;Utdata</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="241"/>
+        <source>Split using separator $0: sep=&apos;$1&apos;</source>
+        <translation>Dela med separator $0: sep=&apos;$1&apos;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="242"/>
+        <source>Split fields using separator</source>
+        <translation>Dela fält med hjälp av separator</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="245"/>
+        <source>File-&gt;Tag &apos;$1&apos;</source>
+        <translation>Fil-&gt;tagg &apos;$1&apos;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="246"/>
+        <source>Filename to Tag</source>
+        <translation>Filnamn till tagg</translation>
+    </message>
+</context>
+<context>
+    <name>Functions Dialog</name>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="28"/>
+        <source>&lt;p&gt;Fields that will
+    get written to.&lt;/p&gt;
+
+    &lt;ul&gt;
+    &lt;li&gt;Enter a list of comma-separated fields
+    eg. &lt;b&gt;artist, title, album&lt;/b&gt;&lt;/li&gt;
+    &lt;li&gt;Use &lt;b&gt;__selected&lt;/b&gt; to write only to the selected cells.
+    It is not allowed when creating an action.&lt;/li&gt;
+    &lt;li&gt;Combinations like &lt;b&gt;__selected, artist, title&lt;/b&gt; are
+    allowed.&lt;/li&gt;
+    &lt;li&gt;But using &lt;b&gt;__selected&lt;/b&gt; in Actions is &lt;b&gt;not&lt;/b&gt;.&lt;/li&gt;
+    &lt;li&gt;&apos;~&apos; will write to all the the fields, except what follows it
+    . Eg &lt;b&gt;~artist, title&lt;/b&gt; will write to all but the artist and
+    title fields found in the selected files.&lt;li&gt;
+    &lt;/ul&gt;</source>
+        <translation>&lt;p&gt;Fält som kommer att
+    skrivas till.&lt;/p&gt;
+
+    &lt;ul&gt;
+    &lt;li&gt;Ange en lista med kommaseparerade fält,
+    t.ex. &lt;b&gt;artist, titel, album&lt;/b&gt;&lt;/li&gt;
+    &lt;li&gt;Använd &lt;b&gt;__selected&lt;/b&gt; för att endast skriva till valda celler.
+    Det är inte tillåtet när en åtgärd skapas.&lt;/li&gt;
+    &lt;li&gt;Kombinationer som &lt;b&gt;__selected, artist, titel&lt;/b&gt; är
+    tillåtet.&lt;/li&gt;
+    &lt;li&gt;Men användning av &lt;b&gt;__selected&lt;/b&gt; i Åtgärder är det &lt;b&gt;inte&lt;/b&gt;.&lt;/li&gt;
+    &lt;li&gt;&apos;~&apos; skriver till alla fält, utom vad som kommer efter det tecknet.
+    &lt;b&gt;~artist, titel&lt;/b&gt; kommer t.ex. att skriva till alla utom till artist- 
+....och titelfälten i de valda filerna.&lt;li&gt;
+    &lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="48"/>
+        <source>&lt;b&gt;No change.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Ingen ändring.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="350"/>
+        <source>No preview for is shown for this function.</source>
+        <translation>Ingen förhandsgranskning för denna funktion.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="365"/>
+        <source>&lt;b&gt;No change&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Ingen ändring&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="421"/>
+        <source>Functions</source>
+        <translation>Funktioner</translation>
+    </message>
+</context>
+<context>
+    <name>GenSettings</name>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="129"/>
+        <source>&amp;Edit sort options</source>
+        <translation>&amp;Redigera sorteringsalternativ</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="133"/>
+        <source>&lt;Autodetect&gt;</source>
+        <translation>&lt;Identifiera automatiskt&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="133"/>
+        <source>Default</source>
+        <translation>Standard</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="154"/>
+        <source>Language (Requires a restart)</source>
+        <translation>Språk (Kräver omstart)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="55"/>
+        <source>Su&amp;bfolders</source>
+        <translation>&amp;Undermappar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="56"/>
+        <source>Show &amp;gridlines</source>
+        <translation>Visa s&amp;tödlinjer</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="57"/>
+        <source>Show tooltips in file-view:</source>
+        <translation>Visa knappbeskrivningar i filvy:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="58"/>
+        <source>Show &amp;row numbers</source>
+        <translation>Visa &amp;radnummer</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="59"/>
+        <source>Automatically resize columns to contents</source>
+        <translation>Anbassa kolumnstorlek automatiskt efter innehåll</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="60"/>
+        <source>&amp;Preserve file modification times</source>
+        <translation>&amp;Bevara filers tidsstämpel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="61"/>
+        <source>Program to &amp;play files with:</source>
+        <translation>Program att s&amp;pela upp filer med:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="62"/>
+        <source>&amp;Load last folder at startup</source>
+        <translation>&amp;Läs in senast använda mapp vid uppstart</translation>
+    </message>
+</context>
+<context>
+    <name>List Buttons</name>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1201"/>
+        <source>Add</source>
+        <translation>Lägg till</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1204"/>
+        <source>Remove</source>
+        <translation>Ta bort</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1208"/>
+        <source>Move Up</source>
+        <translation>Flytta upp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1211"/>
+        <source>Move Down</source>
+        <translation>Flytta ner</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1214"/>
+        <source>Edit</source>
+        <translation>Redigera</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1217"/>
+        <source>Duplicate</source>
+        <translation>Dubblett</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1276"/>
+        <source>&amp;&gt;&gt;</source>
+        <translation>&amp;&gt;&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="1277"/>
+        <source>&amp;&lt;&lt;</source>
+        <translation>&amp;&lt;&lt;</translation>
+    </message>
+</context>
+<context>
+    <name>Logs</name>
+    <message>
+        <location filename="puddlestuff/mainwin/logdialog.py" line="20"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Kopiera</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/logdialog.py" line="21"/>
+        <source>&amp;Clear</source>
+        <translation>&amp;Rensa</translation>
+    </message>
+</context>
+<context>
+    <name>Main Window</name>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="440"/>
+        <source>puddletag: %1 + others</source>
+        <translation>puddletag: %1 + andra</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="442"/>
+        <source>puddletag: %1</source>
+        <translation>puddletag: %1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="451"/>
+        <source>Import directory...</source>
+        <translation>Importmapp...</translation>
+    </message>
+</context>
+<context>
+    <name>Mapping Settings</name>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="255"/>
+        <source>&lt;ul&gt;&lt;li&gt;Tag is the format that the mapping applies to.
+            One of &lt;b&gt;ID3, APEv2, MP4, or VorbisComment&lt;/b&gt;.
+            &lt;/li&gt;&lt;li&gt;Fields will be mapped from Source to Target,
+            meaning that if Source is found in a tag, it&apos;ll be
+            editable in puddletag using Target.&lt;/li&gt;
+            &lt;li&gt;Eg. For &lt;b&gt;Tag=VorbisComment, Source=organization,
+            and Target=publisher&lt;/b&gt; means that writing to the publisher
+            field for VorbisComments in puddletag will in actuality
+            write to the organization field.&lt;/li&gt;&lt;li&gt;Mappings for
+            tag sources are also supported, just use the name of the
+            tag source as Tag, eg. &lt;b&gt;Tag=MusicBrainz,
+            Source=artist,Target=performer&lt;/b&gt;.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>&lt;ul&gt;&lt;li&gt;Tagg är det format som mappningen tillämpar.
+            En av &lt;b&gt;ID3, APEv2, MP4, eller VorbisComment&lt;/b&gt;.
+            &lt;/li&gt;&lt;li&gt;fält kommer att mappas från källa till mål,
+            vilket betyder att om källan hittas i en tagg, blir den
+            redigerbar i puddletag med via målet.&lt;/li&gt;
+            &lt;li&gt;T.ex om &lt;b&gt;Tagg=VorbisComment, Källa=organisation,
+            och Mål=utgivare&lt;/b&gt; betyder det att skrivning till utgivar-
+            fältet för VorbisComments i puddletag egentligen skriver
+            till organisationsfältet.&lt;/li&gt;&lt;li&gt;Mappningar för
+            tagg-källor stöds också, använd bara tagg-källans namn
+            som tagg. T.ex. &lt;b&gt;Tagg=MusicBrainz,
+            Källa=artist, Mål=utförare&lt;/b&gt;.&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="323"/>
+        <source>Tag</source>
+        <translation>Tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="272"/>
+        <source>Original Field</source>
+        <translation>Ursprungligt fält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="323"/>
+        <source>Target</source>
+        <translation>Mål</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="291"/>
+        <source>&lt;b&gt;A restart is required to apply these settings.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Omstart krävs för att tillämpa dessa inställningar.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="323"/>
+        <source>Source</source>
+        <translation>Källa</translation>
+    </message>
+</context>
+<context>
+    <name>Masstagging</name>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="24"/>
+        <source>Continue</source>
+        <translation>Fortsätt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="25"/>
+        <source>Stop</source>
+        <translation>Stoppa</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="28"/>
+        <source>Combine and continue</source>
+        <translation>Kombinera och fortsätt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="29"/>
+        <source>Replace and continue</source>
+        <translation>Ersätt och fortsätt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="30"/>
+        <source>Combine and stop</source>
+        <translation>Kombinera och stoppa</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="31"/>
+        <source>Replace and stop</source>
+        <translation>Ersätt och stoppa</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="34"/>
+        <source>Use best match</source>
+        <translation>Använd bästa matchning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="35"/>
+        <source>Do nothing and continue</source>
+        <translation>Gör ingenting och fortsätt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="60"/>
+        <source>Default Profile</source>
+        <translation>Standardprofil</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="62"/>
+        <source>&lt;b&gt;Polling: %s&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Hämtning: %s&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="63"/>
+        <source>Retrieving matching album. &lt;b&gt;%1 - %2&lt;/b&gt;</source>
+        <translation>Hämtar matchande album. &lt;b&gt;%1 - %2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="65"/>
+        <source>Retrieving matching album. Artist=&lt;b&gt;%1&lt;/b&gt;</source>
+        <translation>Hämtar matchande album. Artist=&lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="67"/>
+        <source>Retrieving matching album. Album=&lt;b&gt;%1&lt;/b&gt;</source>
+        <translation>Hämtar matchande album. Album=&lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="69"/>
+        <source>Retrieving matching album.</source>
+        <translation>Hämtar matchande album.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="71"/>
+        <source>Starting search for: &lt;br /&gt;artist=&lt;b&gt;%1&lt;/b&gt; &lt;br /&gt;album=&lt;b&gt;%2&lt;/b&gt;&lt;br /&gt;</source>
+        <translation>Startar sökning efter: &lt;br /&gt;artist=&lt;b&gt;%1&lt;/b&gt; &lt;br /&gt;album=&lt;b&gt;%2&lt;/b&gt;&lt;br /&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="74"/>
+        <source>Starting search for: &lt;br /&gt;artist=&lt;b&gt;%1&lt;/b&gt;&lt;br /&gt;album=No album name found.</source>
+        <translation>Startar sökning efter: &lt;br /&gt;artist=&lt;b&gt;%1&lt;/b&gt;&lt;br /&gt;album=Inget albumnamn hittades.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="77"/>
+        <source>Starting search for: &lt;br /&gt;album=&lt;b&gt;%1&lt;/b&gt;&lt;br /&gt;artist=No artist found.</source>
+        <translation>Startar sökning efter: &lt;br /&gt;album=&lt;b&gt;%1&lt;/b&gt;&lt;br /&gt;artist=Ingen artist hittades.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="80"/>
+        <source>No artist or album info found in files. Starting search.</source>
+        <translation>Ingen artist- eller albuminfo hittades i filerna. Startar sökning.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="83"/>
+        <source>&lt;b&gt;%d&lt;/b&gt; results found.</source>
+        <translation>&lt;b&gt;%d&lt;/b&gt; resultat hittades.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="84"/>
+        <source>&lt;b&gt;No results were found.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Inga resultat hittades.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="85"/>
+        <source>&lt;b&gt;One&lt;/b&gt; result found.</source>
+        <translation>&lt;b&gt;Ett&lt;/b&gt; resultat hittades.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="87"/>
+        <source>&lt;b&gt;%d&lt;/b&gt; possibly matching albums found.</source>
+        <translation>&lt;b&gt;%d&lt;/b&gt; möjligen matchande album hittades.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="89"/>
+        <source>&lt;b&gt;One&lt;/b&gt; possibly matching album found.</source>
+        <translation>&lt;b&gt;Ett&lt;/b&gt; möjligen matchande album hittades.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="91"/>
+        <source>No matches found for tag source &lt;b&gt;%s&lt;/b&gt;</source>
+        <translation>Inga träffar för taggkällan &lt;b&gt;%s&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="94"/>
+        <source>Previously retrieved result does not match. Retrieving next matching album.</source>
+        <translation>Tidigare hämtat resultat matchar inte. Hämtar nästa matchande album.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="98"/>
+        <source>&lt;br /&gt;Rechecking with results from &lt;b&gt;%s&lt;/b&gt;.&lt;br /&gt;</source>
+        <translation>&lt;br /&gt;Återkontrollerar resultat från &lt;b&gt;%s&lt;/b&gt;.&lt;br /&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="101"/>
+        <source>&lt;br /&gt;Valid matches were found for the album.</source>
+        <translation>&lt;br /&gt;Giltiga matchningar hittades för albumet.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="104"/>
+        <source>&lt;b&gt;No valid matches were found for the album.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Inga giltiga matchningar hittades för albumet..&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="465"/>
+        <source>Rechecking</source>
+        <translation>Återkontroll</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/__init__.py" line="582"/>
+        <source>Retrying search with album name: &lt;b&gt;%s&lt;/b&gt;</source>
+        <translation>Söker igen på albumnamnet &lt;b&gt;%s&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="617"/>
+        <source>An error occured during the search: &lt;b&gt;%s&lt;/b&gt;</source>
+        <translation>Ett fel inträffade under sökning: &lt;b&gt;%s&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="620"/>
+        <source>An error occured during album retrieval: &lt;b&gt;%s&lt;/b&gt;</source>
+        <translation>Ett fel inträffade under albumhämtning: &lt;b&gt;%s&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="493"/>
+        <source>Mass Tagging</source>
+        <translation>Masstaggning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="655"/>
+        <source>&amp;Search</source>
+        <translation>&amp;Sök</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="496"/>
+        <source>&amp;Configure Profiles</source>
+        <translation>&amp;Konfigurera profiler</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="497"/>
+        <source>&amp;Write Previews</source>
+        <translation>Skriv &amp;förhandsgranskning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="498"/>
+        <source>Clear &amp;Preview</source>
+        <translation>&amp;Rensa förhandsgranskning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="523"/>
+        <source>&amp;Profile:</source>
+        <translation>&amp;Profil:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="576"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Stopp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="653"/>
+        <source>&lt;b&gt;Lookups completed.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Sökning slutförd.&lt;/b&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>Menus</name>
+    <message>
+        <location filename="puddlestuff/translations.py" line="71"/>
+        <source>Enabl&amp;e Preview Mode</source>
+        <translation>Akti&amp;vera förhandsgranskning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/previews.py" line="18"/>
+        <source>Disabl&amp;e Preview Mode</source>
+        <translation>&amp;Inktivera förhandsgranskning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="208"/>
+        <source>Help</source>
+        <translation>Hjälp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="213"/>
+        <source>Online &amp;Documentation</source>
+        <translation>Online-&amp;dokumentation</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="217"/>
+        <source>&amp;Forum</source>
+        <translation>&amp;Forum</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="221"/>
+        <source>&amp;Bug tracker</source>
+        <translation>&amp;Felrapportering</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="226"/>
+        <source>About puddletag</source>
+        <translation>Om puddletag</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="230"/>
+        <source>About Qt</source>
+        <translation>Om Qt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="329"/>
+        <source>Toolbar</source>
+        <translation>Verktygsfält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="72"/>
+        <source>Clear Selected &amp;Files</source>
+        <translation>Rensa bort markerade &amp;filer</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="73"/>
+        <source>&amp;Write Previews</source>
+        <translation>&amp;Skriv förhandsgranskning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="74"/>
+        <source>&amp;Undo Last Clear</source>
+        <translation>&amp;Ångra senaste rensning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="78"/>
+        <source>Sort &amp;By</source>
+        <translation>Sortera &amp;efter</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="76"/>
+        <source>Clear Selected &amp;Cells</source>
+        <translation>Rensa markerade &amp;celler</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="77"/>
+        <source>&amp;Plugins</source>
+        <translation>&amp;Insticksmoduler</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="79"/>
+        <source>&amp;Open Folder</source>
+        <translation>&amp;Öppna mapp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="80"/>
+        <source>Select a directory to import into puddletag.</source>
+        <translation>Välj en mapp att importera till puddeltag.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="81"/>
+        <source>&amp;Add Folder</source>
+        <translation>&amp;Lägg till mapp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="82"/>
+        <source>Append a directory to current file-view.</source>
+        <translation>Lägg till en mapp i aktuell filvy.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="83"/>
+        <source>Load &amp;playlist</source>
+        <translation>Läs in &amp;spellista</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="84"/>
+        <source>Import an m3u playlist into puddletag.</source>
+        <translation>Importera en m3u spellista till puddletag.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="85"/>
+        <source>Sa&amp;ve playlist</source>
+        <translation>S&amp;para spellista</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="86"/>
+        <source>Save all files to m3u playlist.</source>
+        <translation>Spara alla filer i en m3u spellista.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="87"/>
+        <source>&amp;Refresh</source>
+        <translation>&amp;Uppdatera</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="88"/>
+        <source>Refresh current file-view.</source>
+        <translation>Uppdatera aktuell filvy</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="89"/>
+        <source>&amp;Save</source>
+        <translation>&amp;Spara</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="90"/>
+        <source>&amp;Play</source>
+        <translation>S&amp;pela upp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="91"/>
+        <source>Plays the selected files in the predefined music player.</source>
+        <translation>Spelar upp markerade filer i fördefinierad musikspelare.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="92"/>
+        <source>&amp;File-&gt;Tag</source>
+        <translation>&amp;Fil-&gt;Tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="93"/>
+        <source>Convert filename to tag using the pattern.</source>
+        <translation>Konvertera filnamn till tagg, med hjälp av mönstret.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="94"/>
+        <source>&amp;Undo</source>
+        <translation>&amp;Ångra</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="95"/>
+        <source>Autonumbering &amp;Wizard...</source>
+        <translation>Autonumrerings&amp;guide</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="96"/>
+        <source>&amp;Unload Everything</source>
+        <translation>&amp;Rensa allt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="97"/>
+        <source>&amp;Format</source>
+        <translation>&amp;Format</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="98"/>
+        <source>&amp;Text File-&gt;Tag</source>
+        <translation>&amp;Textfil-&gt;Tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="99"/>
+        <source>&amp;Import Music Library...</source>
+        <translation>&amp;Importera musikbibliotek</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="140"/>
+        <source>&amp;Actions</source>
+        <translation>&amp;Åtgärder</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="101"/>
+        <source>&amp;Preferences</source>
+        <translation>&amp;Inställningar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="102"/>
+        <source>&amp;Functions</source>
+        <translation>&amp;Funktioner</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="103"/>
+        <source>&amp;QuickActions</source>
+        <translation>&amp;Snabbåtgärder</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="104"/>
+        <source>&amp;Rename Directories</source>
+        <translation>&amp;Namnändra mappar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="105"/>
+        <source>&amp;Exit</source>
+        <translation>A&amp;vsluta</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="106"/>
+        <source>&amp;Tag-&gt;File</source>
+        <translation>&amp;Tagg-&gt;Fil</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="107"/>
+        <source>&amp;Increase Font</source>
+        <translation>&amp;Öka teckenstorlek</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="108"/>
+        <source>&amp;Decrease Font</source>
+        <translation>&amp;Minska teckenstorlek</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="109"/>
+        <source>&amp;Clipboard-&gt;Tag</source>
+        <translation>&amp;Urklipp-&gt;Tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="110"/>
+        <source>Select &amp;All</source>
+        <translation>Markera &amp;alla</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="111"/>
+        <source>&amp;Invert Selection</source>
+        <translation>&amp;Invertera markering</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="112"/>
+        <source>&amp;Select Column</source>
+        <translation>&amp;Välj kolumn</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="113"/>
+        <source>&amp;Cut</source>
+        <translation>&amp;Klipp ut</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="114"/>
+        <source>&amp;Copy Selection</source>
+        <translation>&amp;Kopiera markerat</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="115"/>
+        <source>&amp;Paste</source>
+        <translation>K&amp;listra in</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="116"/>
+        <source>&amp;Remove Tag</source>
+        <translation>&amp;Ta bort tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="117"/>
+        <source>E&amp;xtended Tags</source>
+        <translation>&amp;Utökade taggar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="118"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Ta bort</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="119"/>
+        <source>&amp;Properties</source>
+        <translation>&amp;Egenskaper</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="120"/>
+        <source>Paste &amp;Onto Selection</source>
+        <translation>Klistra in i &amp;markerat</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="121"/>
+        <source>&amp;Lock Layout</source>
+        <translation>&amp;Lås layout</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="122"/>
+        <source>Select &amp;Next Directory</source>
+        <translation>Välj &amp;nästa mapp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="123"/>
+        <source>Copy All &amp;Fields</source>
+        <translation>Kopiera alla &amp;fält</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="124"/>
+        <source>Delete &amp;Without Confirmation</source>
+        <translation>Ta bort &amp;utan att bekräfta</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="125"/>
+        <source>In &amp;Library</source>
+        <translation>I &amp;biblioteket</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="126"/>
+        <source>Replace...</source>
+        <translation>Ersätt...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="127"/>
+        <source>Remove &amp;APEv2 Tag</source>
+        <translation>Ta bort &amp;APEv2-tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="128"/>
+        <source>Remove All &amp;ID3 Tags</source>
+        <translation>Ta bort alla &amp;ID3-taggar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="129"/>
+        <source>Move Selected &amp;Up</source>
+        <translation>Flytta &amp;upp markerat</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="130"/>
+        <source>Move Selected Do&amp;wn</source>
+        <translation>Flytta &amp;ner markerat</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="131"/>
+        <source>Select &amp;Previous Directory</source>
+        <translation>Välj &amp;föregående mapp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="132"/>
+        <source>Select all files belonging to the directories of those selected. Otherwise (if only a single directory is selected) selects all the files in the previous directory.</source>
+        <translation>Välj alla filer som tillhör markerade mappar. Välj annars (om endast en mapp markerad) alla filer i föregående mapp.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="133"/>
+        <source>Remove ID3v&amp;2 Tag</source>
+        <translation>Ta bort ID3v&amp;2-tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="134"/>
+        <source>Remove ID3v&amp;1 Tag</source>
+        <translation>Ta bort ID3v&amp;1-tagg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="135"/>
+        <source>Refresh &amp;Selected</source>
+        <translation>Uppdatera &amp;markerat</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="136"/>
+        <source>Reloads directories of selected files.</source>
+        <translation>Uppdaterar mappar för markerade filer.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="137"/>
+        <source>&amp;File</source>
+        <translation>&amp;Arkiv</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="138"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Redigera</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="139"/>
+        <source>&amp;Convert</source>
+        <translation>&amp;Konvertera</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="141"/>
+        <source>&amp;Tools</source>
+        <translation>&amp;Verktyg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="142"/>
+        <source>&amp;Preview Mode</source>
+        <translation>&amp;Förhandsgranskning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="143"/>
+        <source>Ta&amp;g Tools</source>
+        <translation>&amp;Taggverktyg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/translations.py" line="144"/>
+        <source>&amp;Windows</source>
+        <translation>&amp;Fönster</translation>
+    </message>
+</context>
+<context>
+    <name>Messages</name>
+    <message>
+        <location filename="puddlestuff/mainwin/funcs.py" line="141"/>
+        <source>That&apos;s a large amount of data to copy.
+It may cause your system to lock up.
+
+Do you want to go ahead?</source>
+        <translation>Det är en stor mängd data att kopiera.
+Det kan orsaka att systemet låser sig.
+
+Vill du fortsätta?</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/funcs.py" line="151"/>
+        <source>Copy without images.</source>
+        <translation>Kopiera utan bilder.</translation>
+    </message>
+</context>
+<context>
+    <name>Mp3tag</name>
+    <message>
+        <location filename="puddlestuff/tagsources/mp3tag/__init__.py" line="342"/>
+        <source>Retrieving search page: %s</source>
+        <translation>Hämtar söksida: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/mp3tag/__init__.py" line="343"/>
+        <source>Retrieving search page...</source>
+        <translation>Hämtar söksida...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/mp3tag/__init__.py" line="349"/>
+        <source>Parsing search page.</source>
+        <translation>Tolkar söksida.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/mp3tag/__init__.py" line="350"/>
+        <source>Parsing search page...</source>
+        <translation>Tolkar söksida...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/mp3tag/__init__.py" line="370"/>
+        <source>Retrieving album page: %s</source>
+        <translation>Hämtar albumsida: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/mp3tag/__init__.py" line="371"/>
+        <source>Retrieving album page...</source>
+        <translation>Hämtar albumsida...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/mp3tag/__init__.py" line="376"/>
+        <source>Parsing album page.</source>
+        <translation>Tolkar albumsida.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/mp3tag/__init__.py" line="377"/>
+        <source>Parsing album page...</source>
+        <translation>Tolkar albumsida...</translation>
+    </message>
+</context>
+<context>
+    <name>MusicBrainz</name>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="497"/>
+        <source>&lt;b&gt;Error:&lt;/b&gt; While retrieving %1: %2</source>
+        <translation>&lt;b&gt;Fel&lt;/b&gt; vid hämtning av %1: %2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="550"/>
+        <source>&lt;b&gt;Error:&lt;/b&gt; While retrieving Album ID %1 (%2)</source>
+        <translation>&lt;b&gt;Fel&lt;/b&gt; vid hämtning av album-ID %1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="546"/>
+        <source>Found album id %s in tracks. Retrieving</source>
+        <translation>Hittade album-ID %s i spår. Hämtar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="348"/>
+        <source>Retrieving cover: %s</source>
+        <translation>Hämtar omslag: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="353"/>
+        <source>No images exist for this album.</source>
+        <translation>Det finns inga bilder för det här albumet.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="364"/>
+        <source>Invalid UUID</source>
+        <translation>Ogiltigt UUID</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="366"/>
+        <source>Invalid query sent.</source>
+        <translation>Ogiltig begäran skickad.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="368"/>
+        <source>You have exceeded your rate limit.</source>
+        <translation>Du har överskridit din kvot.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="371"/>
+        <source>Image does not exist.</source>
+        <translation>Bilden finns inte.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="390"/>
+        <source>Retrieving image %s</source>
+        <translation>Hämtar bild %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="479"/>
+        <source>Retrieve Cover</source>
+        <translation>Hämtar omslag</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="480"/>
+        <source>Cover size to retrieve:</source>
+        <translation>Omslagsstorlek att hämta:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="484"/>
+        <source>Amount of images to retrieve:</source>
+        <translation>Antal omslag att hämta:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="485"/>
+        <source>Just the front cover</source>
+        <translation>Endast frontbild</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="486"/>
+        <source>All (can take a while)</source>
+        <translation>Alla (kan ta en stund)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/musicbrainz.py" line="590"/>
+        <source>Error retrieving image: %s</source>
+        <translation>Fel vid hämtning av bild: %s</translation>
+    </message>
+</context>
+<context>
+    <name>MusicLib</name>
+    <message>
+        <location filename="puddlestuff/mainwin/funcs.py" line="232"/>
+        <source>No libraries found</source>
+        <translation>Inga bibliotek hittades</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/funcs.py" line="207"/>
+        <source>Load a lib first.</source>
+        <translation>Läs in ett bibliotek först.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/funcs.py" line="232"/>
+        <source>No supported music libraries were found. Most likely the required dependencies aren&apos;t installed. Visit the puddletag website, &lt;a href=&apos;http://puddletag.sourceforge.net&apos;&gt;puddletag.sourceforge.net&lt;/a&gt; for more details.</source>
+        <translation>Inga musikbibliotek som stöds, hittades. De beroenden som krävs är troligen inte installerade. Besök puddletags webbsida, &lt;a href=&apos;http://puddletag.sourceforge.net&apos;&gt;puddletag.sourceforge.net&lt;/a&gt; för mer info.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="112"/>
+        <source>Import Music Library</source>
+        <translation>Importera musikbibliotek</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="121"/>
+        <source>Invalid library</source>
+        <translation>Ogiltigt bibliotek</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="123"/>
+        <source>Error loading %1: %2
+</source>
+        <translation>Fel vid inläsning av %1: %2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="130"/>
+        <source>Anonymous Library</source>
+        <translation>Anonymt bibliotek</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="134"/>
+        <source>Description was left out.</source>
+        <translation>Beskrivningen saknas.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="138"/>
+        <source>Anonymous author.</source>
+        <translation>Anonym upphovsman.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="188"/>
+        <source>Loading music library...</source>
+        <translation>Läser in musikbibliotek</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="200"/>
+        <source>An error occured while loading the %1 library: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Ett fel inträffade vid inläsning av biblioteket %1: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="457"/>
+        <source>Music Library</source>
+        <translation>Musikbibliotek</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="229"/>
+        <source>&amp;Search</source>
+        <translation>&amp;Sök</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="258"/>
+        <source>Saving music library...</source>
+        <translation>Sparar musikbibliotek</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/musiclib.py" line="279"/>
+        <source>Library Artists</source>
+        <translation>Bibliotekets artister</translation>
+    </message>
+</context>
+<context>
+    <name>Pattern Settings</name>
+    <message>
+        <location filename="puddlestuff/mainwin/patterncombo.py" line="83"/>
+        <source>&amp;Sort</source>
+        <translation>&amp;Sortera</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/patterncombo.py" line="134"/>
+        <source>Enter a pattern</source>
+        <translation>Ange ett mönster</translation>
+    </message>
+</context>
+<context>
+    <name>Playlist</name>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="530"/>
+        <source>Select m3u file...</source>
+        <translation>Välj m3u-fil...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="543"/>
+        <source>An error occured while reading &lt;b&gt;%1&lt;/b&gt; (%2)</source>
+        <translation>Ett fel inträffade vid läsning av &lt;b&gt;%1&lt;/b&gt; (%2)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="677"/>
+        <source>Save Playlist...</source>
+        <translation>Spara spellista...</translation>
+    </message>
+</context>
+<context>
+    <name>Playlist Settings</name>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="213"/>
+        <source>&amp;Write extended info</source>
+        <translation>&amp;Skriv utökad info</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="218"/>
+        <source>Entries &amp;relative to working directory</source>
+        <translation>Poster &amp;relaterade till arbetsmapp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="224"/>
+        <source>&amp;Filename pattern.</source>
+        <translation>&amp;Filnamnsmönster.</translation>
+    </message>
+</context>
+<context>
+    <name>Plugin Settings</name>
+    <message>
+        <location filename="puddlestuff/pluginloader.py" line="97"/>
+        <source>Name</source>
+        <translation>Namn</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/pluginloader.py" line="98"/>
+        <source>Author</source>
+        <translation>Upphovsman</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/pluginloader.py" line="99"/>
+        <source>Description</source>
+        <translation>Beskrivning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/pluginloader.py" line="100"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/pluginloader.py" line="120"/>
+        <source>&lt;b&gt;Loading/unloading plugins requires a restart.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Aktivering/Inaktivering av tillägg, kräver programomstart.&lt;/b&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>Previews</name>
+    <message>
+        <location filename="puddlestuff/mainwin/dirview.py" line="63"/>
+        <source>Some files have uncommited previews. Changes will be lost once you load a directory. &lt;br /&gt;Do you still want to load a new directory?&lt;br /&gt;</source>
+        <translation>Vissa filer har obekräftade ändringar. Ändringarna kommer att förloras när du läser in en mapp. &lt;br /&gt;Vill du fortfarande läsa in en ny mapp?&lt;br /&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/tagtools.py" line="43"/>
+        <source>Disable Preview Mode first to enable tag deletion.</source>
+        <translation>Inaktivera förhandsvisningsläget för att aktivera taggborttagning.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="468"/>
+        <source>Some files have uncommited previews. These changes will be lost once you exit puddletag. &lt;br /&gt;Do you want to exit without writing those changes?&lt;br /&gt;</source>
+        <translation>Vissa filer har obekräftade ändringar. Ändringarna kommer att förloras när du avslutar puddletag. &lt;br /&gt;Vill du avsluta utan att spara ändringarna?&lt;br /&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="511"/>
+        <source>Preview Mode: Off</source>
+        <translation>Förhandsvisningsläge: Av</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="509"/>
+        <source>&lt;b&gt;Preview Mode: On&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Förhandsvisningsläge: På&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="112"/>
+        <source>Do you want to exit Preview Mode?</source>
+        <translation>Vill du inaktivera förhandsvisningsläget?</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="618"/>
+        <source>Clea&amp;r preview</source>
+        <translation>&amp;Rensa förhandsvisningen</translation>
+    </message>
+</context>
+<context>
+    <name>Profile Config</name>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="47"/>
+        <source>Configure Mass Tagging Profiles</source>
+        <translation>Konfigurera masstaggningsprofiler</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="79"/>
+        <source>Masstagging Profiles</source>
+        <translation>Masstaggningsprofiler</translation>
+    </message>
+</context>
+<context>
+    <name>Profile Editor</name>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="190"/>
+        <source>Edit Masstagging Profile</source>
+        <translation>Redigera masstaggningsprofil</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="196"/>
+        <source>Masstagging Profile</source>
+        <translation>Masstaggningsprofil</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="209"/>
+        <source>&lt;p&gt;If no tag information is found in a file, the tags retrieved using this pattern will be used instead.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Om tagginformation inte hittas i en fil, kommer taggar med detta mönster att användas istället.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="384"/>
+        <source>&lt;p&gt;The artist and album fields will be used in determining whether an album matches the retrieved one. Each field will be compared using a fuzzy matching algorithm. If the resulting average match percentage is greater or equal than what you specify here it&apos;ll be considered to match.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Artist- och albumfälten kommer att användas för att avgöra om ett album album matchar det mottagna. Varje enskilt fält jämförs med hjälp av en luddig matchningsalgoritm. Om jämförelseresultatets medelvärde i procent, är större än eller lika med vad du specificerar här, anses det vara en träff.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="225"/>
+        <source>&lt;p&gt;The fields listed here will be used in determining whether a file matches a retrieved track. Each field will be compared using a fuzzy matching algorithm. If the resulting average match percentage is greater than the &quot;Minimum Percentage&quot; it&apos;ll be considered to match.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;De fält som listas här, kommer att användas för att avgöra om en fil matchar ett mottaget spår. Varje enskilt fält jämförs med hjälp av en luddig matchningsalgoritm. Om jämförelseresultatets medelvärde i procent, är större än minimivärdet, anses det vara en träff./p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="366"/>
+        <source>Brute force unmatched files.</source>
+        <translation>Använd råstyrka för omatchade filer.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="239"/>
+        <source>&lt;p&gt;Check to enable brute forcing matches.  If a proper match isn&apos;t found for a file, the files will get sorted by filename, the retrieved tag sources by filename and corresponding (unmatched) tracks will matched.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Aktivera rå beräkningskraft för matchning. Om ingen normal matchning kan hittas för en fil, sorteras filerna efter filnamn, de mottagna taggkällorna efter filnamn och motsvarande (omatchande) spår matchas efter det.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="246"/>
+        <source>Update empty fields only.</source>
+        <translation>Uppdatera endast tomma fält.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="252"/>
+        <source>&amp;Name:</source>
+        <translation>&amp;Namn:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="254"/>
+        <source>&amp;Description</source>
+        <translation>&amp;Beskrivning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="259"/>
+        <source>Pattern to match filenames against.</source>
+        <translation>Mönster att matcha filnamn emot.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="262"/>
+        <source>Minimum percentage required for album matches.</source>
+        <translation>Minimum procentvärde för albummatchning.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="265"/>
+        <source>Match tracks using fields: </source>
+        <translation>Matcha spår med dessa fält: </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="426"/>
+        <source>Minimum percentage required for track match.</source>
+        <translation>Minimivärde i procent, för spårmatchning.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="380"/>
+        <source>Edit Tag Source Config</source>
+        <translation>Redigera taggkällor</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="391"/>
+        <source>&lt;p&gt;Enter a comma-seperated list of fields to retrieve. Leave empty to retrieve all available fields/values. &lt;br /&gt;&lt;br /&gt;Eg. &lt;b&gt;artist, album, title&lt;/b&gt; will only retrieve the artist, album and title fields of from the Tag Source. &lt;br /&gt;&lt;br /&gt;Start the list with the tilde (~) character to write all retrieved fields , but the ones listed. Eg the field list &lt;b&gt;~composer,__image&lt;/b&gt; will write all fields but the composer and __image (aka cover art) fields.&lt;/p&gt;&lt;p&gt;If a field has been retrieved in a previous Tag Source the values will be combined if they differ. Eg. If genre=&lt;b&gt;Rock&lt;/b&gt; for the first tag source polled and genre=&lt;b&gt;Alternative&lt;/b&gt; for the tag source polled second then the resulting field will have multiple-values ie. genre=&lt;b&gt;Rock\\Rap&lt;/b&gt;</source>
+        <translation>&lt;p&gt;Ange en kommaseparerad lista över fält som skall hämtas. Lämnas tom för att hämta alla tillgängliga fält/värden. &lt;br /&gt;&lt;br /&gt;Exempel: &lt;b&gt;artist, album, titel&lt;/b&gt; hämtar endast artist-, album- och titelfälten från taggkällan. &lt;br /&gt;&lt;br /&gt;Starta listan med tilde (~), för att skriva alla hämtade fält, utom de listade. Exempel: De listade fälten &lt;b&gt;~kompositör,__bild&lt;/b&gt; skriver alla fält utom just kompositör och __bild (albumbild).&lt;/p&gt;&lt;p&gt;Om ett fält har hämtats från en tidigare taggkälla, kombineras värdena om de skiljer sig åt. Exempel: Om genre=&lt;b&gt;Rock&lt;/b&gt; från första taggkällan och genre=&lt;b&gt;Rap&lt;/b&gt; från andra taggkällan, kommer genrefältet att få flera värden. Exempelvis, genre=&lt;b&gt;Rock\\Rap&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="413"/>
+        <source>Fields to replace: </source>
+        <translation>Fält att ersätta: </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="415"/>
+        <source>Enter a comma-separated lists of fields that&apos;ll replace any retrieved from previously polled tag sources. &lt;br /&gt;Start the list with the tilde (~) character to replace all but the fields you list. &lt;br /&gt;&lt;b&gt;NB: Fields listed here must also be listed in the list of fields to retrieve.&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;Eg. Assume you have two Tag Sources. The first retrieves &lt;b&gt;artist=Freshlyground, album=Nomvula, genre=Afro Pop&lt;/b&gt;. The second source gets &lt;b&gt;artist=Freshly Ground, album=Nomvula, genre=Pop&lt;/b&gt;. For the second Tag Source, setting just &lt;b&gt;artist&lt;/b&gt; as the list of fields to replace will overwrite the artist field retrieved from the first tag source. The resulting retrieved fields/values as shown in puddletag will then be &lt;b&gt;artist=Freshly Ground, album=Nomvula, genre=Afro Pop\\Pop&lt;/b&gt;.</source>
+        <translation>Ange en kommaseparerad lista över de fält som skall ersätta motsvarande från tidigare taggkällor. &lt;br /&gt;Starta listan med tilde (~), för att ersätta alla, utom de listade. &lt;br /&gt;&lt;b&gt;Fält som listas här, måste också finnas i listan över fält som skall hämtas.&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;Exempel: Anta att du har två taggkällor. Från den första hämtas &lt;b&gt;artist=Freshlyground, album=Nomvula, genre=Afro Pop&lt;/b&gt;. Från den andra källan hämtas &lt;b&gt;artist=Freshly Ground, album=Nomvula, genre=Pop&lt;/b&gt;. Om du för den andra taggkällan sätter enbart &lt;b&gt;artist&lt;/b&gt; i listan som skall ersätta tidigare taggkällor, kommer endast artistfältet att skrivas över, från den första taggkällan. Det färdiga resultatet som visas i puddletag blir då &lt;b&gt;artist=Freshly Ground, album=Nomvula, genre=Afro Pop\\Pop&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="438"/>
+        <source>&amp;Source</source>
+        <translation>&amp;Källa</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="443"/>
+        <source>&amp;If no results found: </source>
+        <translation>&amp;Om inga träffar hittas: </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/masstag/dialogs.py" line="445"/>
+        <source>&lt;p&gt;&lt;b&gt;Continue&lt;/b&gt;: The lookup for the current album will continue by checking the other tag sources if no matching results were found for this tag source.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Stop:&lt;/b&gt; The lookup for the current album will stop and any previously retrieved results will be used.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;b&gt;Fortsätt&lt;/b&gt;: Uppslagning på aktuellt album fortsätter genom att kontrollera de andra källorna, om inga matchande resultat hittades i denna källa.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Stoppa&lt;/b&gt;: Uppslagning på aktuellt album stoppas och alla tidigare hämtade resultat kommer att användas.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="368"/>
+        <source>&lt;p&gt;If a proper match isn&apos;t found for a file, the files will get sorted by filename, the retrieved tag sources by filename and corresponding (unmatched) tracks will matched.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Om en korrekt matchning inte kan hittas för en fil, sorteras filerna efter filnamn, de hämtade taggkällorna efter filnamn och motsvarande (omatchade) spår matchas.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="375"/>
+        <source>&lt;p&gt;The fields listed here will be used in determining whether a track matches the retrieved track. Each field will be compared using a fuzzy matching algorithm. If the resulting average match percentage is greater than the &quot;Minimum Percentage&quot; it&apos;ll be considered to match.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;De fält som listas här, kommer att användas för att avgöra om ett spår matchar det hämtade spåret. Varje enskilt fält jämförs med hjälp av en luddig matchningsalgoritm. Om jämförelseresultatets medelvärde i procent, är större än minimivärdet, anses det vara en träff.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="421"/>
+        <source>Minimum &amp;percentage required for album matches.</source>
+        <translation>Minimivärde i &amp;procent, för albummatchning.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="424"/>
+        <source>Match tracks using &amp;fields: </source>
+        <translation>Matcha spår med &amp;fälten: </translation>
+    </message>
+</context>
+<context>
+    <name>Progress Dialog</name>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="2025"/>
+        <source>Please Wait...</source>
+        <translation>Vänta...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddleobjects.py" line="2026"/>
+        <source>%1%2 of %3...</source>
+        <translation>%1%2 av %3...</translation>
+    </message>
+</context>
+<context>
+    <name>QuodLibet</name>
+    <message>
+        <location filename="puddlestuff/libraries/quodlibetlib.py" line="357"/>
+        <source>&amp;Library Path</source>
+        <translation>&amp;Bibliotekssökväg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/libraries/quodlibetlib.py" line="360"/>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/libraries/quodlibetlib.py" line="371"/>
+        <source>Select QuodLibet library file...</source>
+        <translation>Välj QuodLibet biblioteksfil...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/libraries/quodlibetlib.py" line="382"/>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/libraries/quodlibetlib.py" line="385"/>
+        <source>%1 is an invalid QuodLibet music library file.</source>
+        <translation>%1 är ett ogiltigt QuodLibet musikbibliotek.</translation>
+    </message>
+</context>
+<context>
+    <name>Settings</name>
+    <message>
+        <location filename="puddlestuff/mainwin/patterncombo.py" line="70"/>
+        <source>Patterns</source>
+        <translation>Mönster</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/tagpanel.py" line="425"/>
+        <source>Tag Panel</source>
+        <translation>Taggpanel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="605"/>
+        <source>General</source>
+        <translation>Allmänt</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="607"/>
+        <source>Confirmations</source>
+        <translation>Bekräftelser</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="609"/>
+        <source>Mappings</source>
+        <translation>Kartläggningar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="610"/>
+        <source>Playlist</source>
+        <translation>Spellista</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="611"/>
+        <source>Colours</source>
+        <translation>Färger</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="612"/>
+        <source>Genres</source>
+        <translation>Genrer</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="614"/>
+        <source>Tags</source>
+        <translation>Taggar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="616"/>
+        <source>Plugins</source>
+        <translation>Insticksmoduler</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="617"/>
+        <source>Shortcuts</source>
+        <translation>Genvägar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="678"/>
+        <source>An error occurred while saving the settings of &lt;b&gt;%1&lt;/b&gt;: %2</source>
+        <translation>Ett fel inträffade när inställningarna för &lt;b&gt;%1&lt;/b&gt; skulle sparas: %2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddletag.py" line="341"/>
+        <source>&amp;Windows</source>
+        <translation>&amp;Fönster</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="343"/>
+        <source>Tag Sources</source>
+        <translation>Taggkällor</translation>
+    </message>
+</context>
+<context>
+    <name>Shortcut Editor</name>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="59"/>
+        <source>Enter a key sequence for the shortcut.</source>
+        <translation>Ange en tangentkombination för genvägen.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/actiondlg.py" line="63"/>
+        <source>&amp;Don&apos;t assign keyboard shortcut.</source>
+        <translation>&amp;Tilldela ingen tangentbordsgenväg.</translation>
+    </message>
+</context>
+<context>
+    <name>Shortcut Settings</name>
+    <message>
+        <location filename="puddlestuff/shortcutsettings.py" line="206"/>
+        <source>&lt;b&gt;Double click a cell in the Shortcut Column to &lt;br /&gt;modify the key sequence.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Dubbelklicka på en cell i genvägskolumnen för att &lt;br /&gt;ändra tangentkombinationen.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/shortcutsettings.py" line="213"/>
+        <source>Description</source>
+        <translation>Beskrivning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/shortcutsettings.py" line="213"/>
+        <source>Shortcut</source>
+        <translation>Genväg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/shortcutsettings.py" line="257"/>
+        <source>Edit Shortcuts</source>
+        <translation>Redigera genväg</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="332"/>
+        <source>File Properties</source>
+        <translation>Filegenskaper</translation>
+    </message>
+</context>
+<context>
+    <name>Shortcuts</name>
+    <message>
+        <location filename="puddlestuff/action_shortcuts.py" line="150"/>
+        <source>&amp;Clear</source>
+        <translation>&amp;Rensa</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/action_shortcuts.py" line="174"/>
+        <source>Invalid shortcut sequence.</source>
+        <translation>Ogiltig tangentkombination.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/action_shortcuts.py" line="243"/>
+        <source>(Deleted)</source>
+        <translation>(Borttagen)</translation>
+    </message>
+</context>
+<context>
+    <name>Status Bar</name>
+    <message>
+        <location filename="puddlestuff/mainwin/funcs.py" line="484"/>
+        <source>&lt;b&gt;%s&lt;/b&gt;</source>
+        <translation>&lt;b&gt;%s&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/funcs.py" line="490"/>
+        <source>New Filename: &lt;b&gt;%1&lt;/b&gt;</source>
+        <translation>Nytt filnamn: &lt;b&gt;%1&lt;/b&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>Table</name>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="686"/>
+        <source>Preview: %1
+Real: %2</source>
+        <translation>Förhandsgranskning: %1
+Aktuell: %2</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1529"/>
+        <source>Disable Preview Mode first to enable tag deletion.</source>
+        <translation>Inaktivera förhandsgranskningsläget först, för att aktivera taggborttagning.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1539"/>
+        <source>An error occurred while deleting the tag of %1: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Ett fel inträffade vid borttagning av taggen för %1: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1548"/>
+        <source>There was an error deleting the tag of %1: &lt;b&gt;Tag deletion isn&apos;t supportedfor %2 files.&lt;/b&gt;</source>
+        <translation>Ett fel inträffade vid borttagning av taggen för %1: &lt;b&gt;Taggborttagning stöds inte för %2-filer.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1557"/>
+        <source>Deleting tag... </source>
+        <translation>Tar bort tagg... </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1587"/>
+        <source>Are you sure you want to delete the selected files?</source>
+        <translation>Vill du verkligen ta bort de valda filerna?</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1628"/>
+        <source>Deleting </source>
+        <translation>Tar bort</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1977"/>
+        <source>An error occurred while trying to play the selected files: &lt;b&gt;%1&lt;/b&gt; &lt;br /&gt;Does the music player you defined (&lt;b&gt;%2&lt;/b&gt;) exist?</source>
+        <translation>Ett fel inträffade vid försök att spela upp de valda filerna: &lt;b&gt;%1&lt;/b&gt; &lt;br /&gt;Finns din specificerade musikspelare (&lt;b&gt;%2&lt;/b&gt;)?</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagmodel.py" line="1984"/>
+        <source>It wasn&apos;t possible to play the selected files, because the music player you defined (&lt;b&gt;%1&lt;/b&gt;) does not exist.</source>
+        <translation>Det gick inte att spela upp de valda filerna, eftersom din specificerade musikspelare (&lt;b&gt;%1&lt;/b&gt;) inte finns.</translation>
+    </message>
+</context>
+<context>
+    <name>Tag Panel Settings</name>
+    <message>
+        <location filename="puddlestuff/mainwin/tagpanel.py" line="419"/>
+        <source>Row</source>
+        <translation>Rad</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/mainwin/tagpanel.py" line="475"/>
+        <source>All row numbers must be integers.</source>
+        <translation>Alla radnummer måste vara heltal.</translation>
+    </message>
+</context>
+<context>
+    <name>Tag Settings</name>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="381"/>
+        <source>&amp;Restrict incoming files to (eg. &quot;*.mp3; *.ogg; *.aac&quot;)</source>
+        <translation>&amp;Begränsa inkommande filer till (Exempel: &quot;*.mp3; *.ogg; *.aac&quot;)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="385"/>
+        <source>Remove ID3v1 tag.</source>
+        <translation>Ta bort ID3v1-taggar.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="386"/>
+        <source>Update the ID3v1 tag&apos;s values only if an ID3v1 tag is present.</source>
+        <translation>Uppdatera ID3v1-taggar endast om ID3v1-taggar finns.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="388"/>
+        <source>Create an ID3v1 tag if it&apos;s not present. Otherwise update it.</source>
+        <translation>Skapa en ID3v1-tagg om den inte finns. Annars uppdatera den.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="393"/>
+        <source>puddletag writes only &amp;ID3v2 tags.&lt;br /&gt;What should be done with the ID3v1 tag upon saving?</source>
+        <translation>puddletag skriver endast &amp;ID3v2-taggar.&lt;br /&gt;Vad skall göras med ID3v1-taggen när du sparar?</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="399"/>
+        <source>Default &amp;pattern to use when saving artwork.</source>
+        <translation>Standard&amp;mönster att användas när albumbilder sparas.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="415"/>
+        <source>ID3 Options</source>
+        <translation>ID3-alternativ</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="417"/>
+        <source>Write ID3v2.&amp;4</source>
+        <translation>Skriv ID3v2.&amp;4</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/puddlesettings.py" line="420"/>
+        <source>Write ID3v2.&amp;3</source>
+        <translation>Skriv ID3v2.&amp;3</translation>
+    </message>
+</context>
+<context>
+    <name>Tag Sources</name>
+    <message>
+        <location filename="puddlestuff/tagsources/__init__.py" line="89"/>
+        <source>&lt;b&gt;Error parsing artist/album combinations.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Fel vid tolkning av artist-/albumkombinationer.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/__init__.py" line="94"/>
+        <source>Retrieving cover: %s</source>
+        <translation>Hämtar omslag: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/__init__.py" line="150"/>
+        <source>HTTPError 403: Forbidden</source>
+        <translation>HTTP-fel 403: Förbjudet</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/tagsources/__init__.py" line="152"/>
+        <source>Page doesn&apos;t exist</source>
+        <translation>Sidan finns inte</translation>
+    </message>
+</context>
+<context>
+    <name>Text File -&gt; Tag</name>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="150"/>
+        <source>Import tags from text file</source>
+        <translation>Importera taggar från textfil</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="156"/>
+        <source>Text</source>
+        <translation>Text</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="159"/>
+        <source>Tag preview</source>
+        <translation>Taggförhandsgranskning</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="180"/>
+        <source>&amp;Select File</source>
+        <translation>&amp;Välj fil</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="182"/>
+        <source>&amp;Paste Clipboard</source>
+        <translation>&amp;Klistra in från urklipp</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="246"/>
+        <source>The file &lt;b&gt;%1&lt;/b&gt; couldn&apos;t be loaded.&lt;br /&gt; Do you want to choose another?</source>
+        <translation>Filen &lt;b&gt;%1&lt;/b&gt; kunde inte läsas in.&lt;br /&gt; Vill du välja en annan?</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="250"/>
+        <source>Error</source>
+        <translation>Fel</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="250"/>
+        <source>&amp;Yes</source>
+        <translation>&amp;Ja</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/helperwin.py" line="250"/>
+        <source>&amp;No</source>
+        <translation>&amp;Nej</translation>
+    </message>
+</context>
+<context>
+    <name>WebDB</name>
+    <message>
+        <location filename="puddlestuff/releasewidget.py" line="24"/>
+        <source>Retrieved Albums (sorted by %s)</source>
+        <translation>Hämtade album (sorterade efter %s)</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/releasewidget.py" line="83"/>
+        <source>&lt;b&gt;Error in pattern&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Fel i mönstret&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/releasewidget.py" line="244"/>
+        <source>Retrieved Albums</source>
+        <translation>Hämtade album</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="871"/>
+        <source>An error occured: %1</source>
+        <translation>Ett fel inträffade: %1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/releasewidget.py" line="452"/>
+        <source>An unhandled error occured: %1</source>
+        <translation>Ett obearbetat fel inträffade: %1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/releasewidget.py" line="365"/>
+        <source>Retrieving album tracks...</source>
+        <translation>Hämtar albumspår...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/releasewidget.py" line="464"/>
+        <source>Retrieval complete.</source>
+        <translation>Hämtnin slutförd.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/releasewidget.py" line="470"/>
+        <source>Retrieving tracks...</source>
+        <translation>Hämtar spår...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="816"/>
+        <source>No matching albums were found.</source>
+        <translation>Inga matchande album hittades.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/releasewidget.py" line="691"/>
+        <source>More than one album matches. None will be retrieved.</source>
+        <translation>Fler än ett album matchar. Inget hämtas.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/releasewidget.py" line="694"/>
+        <source>Retrieving album.</source>
+        <translation>Hämtar album.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="32"/>
+        <source>Enter search parameters here. If empty, the selected files are used. &lt;ul&gt;&lt;li&gt;&lt;b&gt;artist;album&lt;/b&gt; searches for a specific album/artist combination.&lt;/li&gt;&lt;li&gt;To list the albums by an artist leave off the album part, but keep the semicolon (eg. &lt;b&gt;Ratatat;&lt;/b&gt;). For a album only leave the artist part as in &lt;b&gt;;Resurrection.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Ange sökparametrar här. De valda filerna används om fältet lämnas tomt. &lt;ul&gt;&lt;li&gt;&lt;b&gt;artist;album&lt;/b&gt; söker specifikt efter album-/artistkombination.&lt;/li&gt;&lt;li&gt;Utelämna albumdelen, men lämna kvar semikolon, för att lista album av en artist (exempel: &lt;b&gt;Ratatat;&lt;/b&gt;). För endast ett album, lämna kvar artistdelen, som i &lt;b&gt;;Resurrection.&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="41"/>
+        <source>Enter a comma seperated list of fields to write. &lt;br /&gt;&lt;br /&gt;Eg. &lt;b&gt;artist, album, title&lt;/b&gt; will only write the artist, album and title fields of the retrieved tags. &lt;br /&gt;&lt;br /&gt;If you want to exclude some fields, but write all others start the list the tilde (~) character. Eg &lt;b&gt;~composer, __image&lt;/b&gt; will write all fields but the composer and __image fields.</source>
+        <translation>Ange en kommaseparerad lista över fält att skriva &lt;br /&gt;&lt;br /&gt;Exempel: &lt;b&gt;artist, album, title&lt;/b&gt; skriver endast artist-, album och titelfälten från de hämtade taggarna. &lt;br /&gt;&lt;br /&gt;Om du vill utesluta några fält, men skriva alla andra, startar du listan med tilde (~). Exempel: &lt;b&gt;~composer, __image&lt;/b&gt; skriver alla fält, men utelämnar kompositörs- och bildfältet.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="78"/>
+        <source>&lt;b&gt;Nothing to display.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Det finns inget att visa.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="94"/>
+        <source>Couldn&apos;t load Mp3tag Tag Source %s</source>
+        <translation>Kunde inte läsa in Mp3-taggens källa %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="214"/>
+        <source>Configure: %s</source>
+        <translation>Konfigurera: %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="305"/>
+        <source>Add sort option</source>
+        <translation>Lägg till sorteringsalternativ</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="323"/>
+        <source>Enter a sorting option (a comma-separated list of fields. Eg. &quot;artist, title&quot;)</source>
+        <translation>Ange ett sorteringsalternativ (En kommaseparerad lista med fält. Exempelvis: &quot;artist, title&quot;).</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="323"/>
+        <source>Edit sort option</source>
+        <translation>Redigera sorteringsalternativ</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="345"/>
+        <source>&amp;Display format for individual tracks.</source>
+        <translation>&amp;Visa format för individuella spår</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="350"/>
+        <source>Display format for &amp;retrieved albums</source>
+        <translation>Visa format för &amp;hämtade album</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="355"/>
+        <source>Sort retrieved albums using order:</source>
+        <translation>Sortera hämtade album efter:</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="362"/>
+        <source>User-Agent to when accessing web sites.</source>
+        <translation>User-Agent för att besöka webbsidor.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="415"/>
+        <source>Automatic retrieval options</source>
+        <translation>Automatiska hämtningsalternativ</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="593"/>
+        <source>Sour&amp;ce: </source>
+        <translation>K&amp;älla: </translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="598"/>
+        <source>Configure</source>
+        <translation>Konfigurera</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="606"/>
+        <source>&amp;Search</source>
+        <translation>&amp;Sök</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="615"/>
+        <source>&amp;Write</source>
+        <translation>S&amp;kriv</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="622"/>
+        <source>Select files and click on Search to retrieve metadata.</source>
+        <translation>Markera filer och tryck på Sök, för att hämta metadata.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="627"/>
+        <source>Update empty fields only.</source>
+        <translation>Uppdatera endast tomma fält.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="633"/>
+        <source>Automatically retrieve matches.</source>
+        <translation>Hämta matchningar automatiskt.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="813"/>
+        <source>Searching complete.</source>
+        <translation>Sökning slutförd.</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="830"/>
+        <source>Searching...</source>
+        <translation>Söker...</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="835"/>
+        <source>&lt;b&gt;Select some files or enter search paramaters.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Markera några filer, eller ange sökparametrar.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="875"/>
+        <source>An unhandled error occurred: %1</source>
+        <translation>Ett obearbetat fel inträffade: %1</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="904"/>
+        <source>&lt;b&gt;Tags were written.&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Taggar skrevs.&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="552"/>
+        <source>Retrying search with %s</source>
+        <translation>Söker igen med %s</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="611"/>
+        <source>S&amp;ubmit Tags</source>
+        <translation>&amp;Föreslå taggar</translation>
+    </message>
+    <message>
+        <location filename="puddlestuff/webdb.py" line="878"/>
+        <source>Submission completed.</source>
+        <translation>Förslag skickat.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Hi,
Very good tag editor, but it really needs a Swedish translation, so here it is. 

I can't find a place to put translations folder/.qm file, for more permanent testing use. Is it possible?
I know about the --langfile command but as said, I would like it more permanent.

Thanks for the application