### PR TITLE
Add shutil.move fail-back for os.rename

### DIFF
--- a/source/puddlestuff/util.py
+++ b/source/puddlestuff/util.py
@@ -20,6 +20,7 @@ from operator import itemgetter
 from itertools import imap
 
 from xml.sax.saxutils import escape as escape_html
+import shutil
 
 ARTIST = 'artist'
 ALBUM = 'album'
@@ -70,7 +71,12 @@ def rename(oldpath, newpath):
         os.rename(oldpath, newpath)
         return True
     except EnvironmentError, e:
-        raise RenameError(e, oldpath, newpath)
+        try:
+            shutil.move(oldpath, newpath)
+            return True
+        except EnvironmentError, e:
+            raise RenameError(e, oldpath, newpath)
+
 
 def rename_dir(filename, olddir, newdir):
     if newdir == olddir:


### PR DESCRIPTION
Add shutil.move function as fail-back for method for events where os.rename fails.  when the source and destination are not the same volume, the os.rename function fails with "Invalid cross-device link" error.  This can occur when the tag pattern contains an absolute path

more info: http://puddletag.sourceforge.net/forum/viewtopic.php?f=3&t=274&p=1313#p1313