### PR TITLE
Use mutagen type detection for Ogg Vorbis files

### DIFF
--- a/source/puddlestuff/audioinfo/vorbis.py
+++ b/source/puddlestuff/audioinfo/vorbis.py
@@ -294,7 +294,7 @@ class FLAC_Tag(vorbis_tag(FLAC, u'FLAC')):
     info = property(_info)
 
 filetypes = [
-    (OggVorbis, Ogg_Tag, u'VorbisComment', 'ogg'),
+    (OggVorbis, Ogg_Tag, u'VorbisComment', None),
     (FLAC, FLAC_Tag, u'VorbisComment', 'flac')]
 
 if OggOpus:


### PR DESCRIPTION
Fixes #357.

This allows Ogg Opus files with the .ogg extension to be detected correctly using mutagen's score mechanism. I have tested this with Ogg opus and Ogg vorbis files.